### PR TITLE
Only apply last-child margins to modified children

### DIFF
--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -11,10 +11,10 @@ const ColumnStack = styled(AminoStack)`
 
   & > * {
     margin-bottom: var(--amino-space-quarter);
-  }
 
-  & :last-child {
-    margin-bottom: 0;
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 `;
 
@@ -24,10 +24,10 @@ const RowStack = styled(AminoStack)`
 
   & > * {
     margin-right: var(--amino-space-quarter);
-  }
 
-  & :last-child {
-    margin-right: 0;
+    &:last-child {
+      margin-right: 0;
+    }
   }
 `;
 
@@ -36,10 +36,11 @@ const CardStack = styled.div`
 
   & > * {
     margin-bottom: var(--amino-space);
-  }
 
-  & :last-child {
-    margin-bottom: 0;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 `;
 


### PR DESCRIPTION
![Screen Shot 2020-08-04 at 7 12 14 PM](https://user-images.githubusercontent.com/5748275/89360678-724f9000-d686-11ea-92b9-d41d1f3cb8c7.png)

This is messing with the proper margins for:

```tsx
<Stack type={StackType.cards}>
  <Card>
    <List>
      <ListItem />
      ...
    </List>
  </Card>
</Stack>
```