### PR TITLE
fix(button): clarify onclick type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "2.50.0",
+  "version": "2.51.0",
   "description": "Core UI components for Amino",
   "main": "dist/index.js",
   "repository": "git@github.com:amino-ui/core.git",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -4,7 +4,6 @@ import ReactTooltip from "react-tooltip";
 
 import { AminoTheme } from "../../styles/AminoTheme";
 import { Spinner } from "../Spinner";
-import { AminoOnClickHandler } from "../..";
 
 const AminoButton = styled.button`
   position: relative;
@@ -101,7 +100,7 @@ type Props = {
   intent?: "primary" | "danger" | "icon" | "secondary";
   loading?: boolean;
   disabled?: boolean;
-  onClick?: AminoOnClickHandler;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   className?: string;
   loadingText?: string;
   tabIndex?: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,6 @@ export { Skeleton } from "./components/Skeleton";
 export { Depth, Surface } from "./primitives";
 
 export { AminoOnSaveHandler } from "./utils/AminoOnSaveHandler";
-export { AminoOnClickHandler } from "./utils/AminoOnClickHandler";
 
 export { useInputValue } from "./hooks/useInputValue";
 export { useCheckboxValue } from "./hooks/useCheckboxValue";

--- a/src/utils/AminoOnClickHandler.ts
+++ b/src/utils/AminoOnClickHandler.ts
@@ -1,3 +1,0 @@
-export type AminoOnClickHandler = (
-  event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-) => void;


### PR DESCRIPTION
### Description
This PR clarifies the onClick event type from the Button. Inferring the type was only showing AminoClickHandler instead of showing the actual type.