### PR TITLE
Add dark wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "2.57.0",
+  "version": "2.58.0",
   "description": "Core UI components for Amino",
   "main": "dist/index.js",
   "repository": "git@github.com:amino-ui/core.git",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -50,8 +50,7 @@ const Primary = styled(AminoButton)`
 `;
 
 const Secondary = styled(AminoButton)`
-  background: white;
-  color: var(${AminoTheme.textDark});
+  color: var(--amino-text-color);
   border: var(${AminoTheme.border});
   background: var(${AminoTheme.inputBackground});
 
@@ -61,7 +60,7 @@ const Secondary = styled(AminoButton)`
 `;
 
 const Icon = styled(AminoButton)`
-  background: white;
+  background: var(${AminoTheme.inputBackground});
   color: var(${AminoTheme.textColor});
   border: var(${AminoTheme.border});
   padding: 0 var(${AminoTheme.spaceHalf});

--- a/src/components/DarkModeWrapper/DarkModeWrapper.tsx
+++ b/src/components/DarkModeWrapper/DarkModeWrapper.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 
 type Props = {
-  forceDarkMode?: boolean;
   children: React.ReactNode;
 };
 
-export const DarkModeWrapper = ({ forceDarkMode, children }: Props) => (
+export const DarkModeWrapper = ({ children }: Props) => (
   <div data-theme="dark">{children}</div>
 );

--- a/src/components/DarkModeWrapper/DarkModeWrapper.tsx
+++ b/src/components/DarkModeWrapper/DarkModeWrapper.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+type Props = {
+  forceDarkMode?: boolean;
+  children: React.ReactNode;
+};
+
+export const DarkModeWrapper = ({ forceDarkMode, children }: Props) => (
+  <div data-theme="dark">{children}</div>
+);

--- a/src/components/DarkModeWrapper/index.ts
+++ b/src/components/DarkModeWrapper/index.ts
@@ -1,0 +1,1 @@
+export { DarkModeWrapper } from "./DarkModeWrapper";

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -14,8 +14,8 @@ const Backdrop = styled.div`
   height: 100vh;
   left: 0;
   top: 0;
-  background: var(${AminoTheme.gray900});
-  opacity: .8;
+  background: var(--amino-backdrop-color);
+  opacity: 0.8;
   z-index: 999;
   position: fixed;
 `;
@@ -30,12 +30,13 @@ const DialogLayout = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  color: var(--amino-text-color);
 `;
 
 const Popup = styled.div`
   position: relative;
   z-index: 1001;
-  background: var(${AminoTheme.surfaceColor});
+  background: var(--amino-surface-color);
   width: 550px;
   border-radius: var(${AminoTheme.radiusLg});
   outline: none;
@@ -76,13 +77,22 @@ const Content = styled.div`
   overscroll-behavior: contain;
 `;
 
+type IAminoTheme = "dark" | "light";
+
 type Props = {
   open: boolean;
   label?: string;
   actions?: Array<React.ReactNode>;
+  theme?: IAminoTheme;
 };
 
-export const Dialog: React.FC<Props> = ({ open, label, actions, children }) => {
+export const Dialog: React.FC<Props> = ({
+  theme,
+  open,
+  label,
+  actions,
+  children
+}) => {
   const toggleScroll = () => document.body.classList.toggle("no-scroll");
 
   return ReactDOM.createPortal(
@@ -95,7 +105,7 @@ export const Dialog: React.FC<Props> = ({ open, label, actions, children }) => {
         onEnter={toggleScroll}
         onExit={toggleScroll}
       >
-        <Backdrop />
+        <Backdrop data-theme={theme} />
       </CSSTransition>
       <CSSTransition
         unmountOnExit
@@ -103,7 +113,7 @@ export const Dialog: React.FC<Props> = ({ open, label, actions, children }) => {
         timeout={300}
         classNames="amino-dialog"
       >
-        <DialogLayout>
+        <DialogLayout data-theme={theme}>
           <Popup>
             <Header>
               <Text style={TextStyle.h4}>{label}</Text>
@@ -120,6 +130,6 @@ export const Dialog: React.FC<Props> = ({ open, label, actions, children }) => {
         </DialogLayout>
       </CSSTransition>
     </>,
-    document.querySelector('body')!
+    document.querySelector("body")!
   );
 };

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -49,7 +49,7 @@ const Content = styled.div`
 `;
 
 const Header = styled.header`
-  background: white;
+  background: var(--amino-sidebar-color);
   box-shadow: var(${AminoTheme.shadowSmall});
   border-bottom: var(${AminoTheme.border});
   height: var(${AminoTheme.appbarHeight});
@@ -74,9 +74,7 @@ export const Layout: React.FC<Props> = ({
 }) => {
   return (
     <AminoLayout>
-      <Header>
-        {headerContent}
-      </Header>
+      <Header>{headerContent}</Header>
       <ContentGrid>
         <Sidebar>
           <SidebarContent>{sidebar}</SidebarContent>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -48,6 +48,7 @@ const SelectWrapper = styled.div`
     height: 16px;
     opacity: 0.3;
     transition: opacity 100ms ease-in-out;
+    color: var(--amino-text-color);
   }
 
   &:hover svg {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -7,7 +7,7 @@ const AminoTabs = styled.div`
   display: flex;
   align-items: center;
   border: var(${AminoTheme.border});
-  background: white;
+  background: var(--amino-surface-color);
   border-radius: var(${AminoTheme.radiusLg});
 `;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,4 @@ export { VStack } from "./components/Stack";
 export { HStack } from "./components/Stack";
 
 export { AminoTheme } from "./styles/AminoTheme";
+export { DarkModeWrapper } from "./components/DarkModeWrapper";

--- a/src/primitives/Surface.tsx
+++ b/src/primitives/Surface.tsx
@@ -7,6 +7,7 @@ import { Depth } from "./Depth";
 const SurfaceBase = styled.div<any>`
   background: var(${AminoTheme.surfaceColor});
   padding: var(${AminoTheme.space});
+  color: var(--amino-text-color);
   border-radius: ${p =>
     p.dense ? `var(${AminoTheme.radius})` : `var(${AminoTheme.radiusLg})`};
 `;

--- a/src/styles/amino.css
+++ b/src/styles/amino.css
@@ -32,6 +32,7 @@ h4,
 h5,
 h6 {
   font-family: var(--amino-font-sans);
+  color: var(--amino-text-color);
 }
 
 h1 {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -174,6 +174,6 @@
   --amino-text-color: white;
   --amino-input-background: var(--amino-gray-300);
   --amino-hover-color: var(--amino-gray-400);
-
+  --amino-sidebar-color: vaR(--amino-gray-50);
   --amino-border: 1px solid var(--amino-border-color);
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -26,16 +26,16 @@
   --amino-radius: 0.375em;
   --amino-radius-lg: 0.5em;
 
-  --amino-gray-50: #f9fafb;
-  --amino-gray-100: #f4f5f7;
-  --amino-gray-200: #e5e7eb;
-  --amino-gray-300: #d2d6dc;
-  --amino-gray-400: #9fa6b2;
-  --amino-gray-500: #6b7280;
-  --amino-gray-600: #4b5563;
-  --amino-gray-700: #374151;
-  --amino-gray-800: #252f3f;
-  --amino-gray-900: #171e2e;
+  --amino-gray-50: #fafbfc;
+  --amino-gray-100: #f6f8fa;
+  --amino-gray-200: #e1e4e8;
+  --amino-gray-300: #d1d5da;
+  --amino-gray-400: #959da5;
+  --amino-gray-500: #6a737d;
+  --amino-gray-600: #586069;
+  --amino-gray-700: #444d56;
+  --amino-gray-800: #2f363d;
+  --amino-gray-900: #24292e;
 
   --amino-blue-alpha: #2190ff80;
   --amino-blue-50: #ebf5ff;
@@ -155,16 +155,16 @@
 }
 
 [data-theme="dark"] {
-  --amino-gray-50: #171e2e;
-  --amino-gray-100: #252f3f;
-  --amino-gray-200: #374151;
-  --amino-gray-300: #4b5563;
-  --amino-gray-400: #6b7280;
-  --amino-gray-500: #9fa6b2;
-  --amino-gray-600: #d2d6dc;
-  --amino-gray-700: #e5e7eb;
-  --amino-gray-800: #f4f5f7;
-  --amino-gray-900: #f9fafb;
+  --amino-gray-50: #24292e;
+  --amino-gray-100: #2f363d;
+  --amino-gray-200: #444d56;
+  --amino-gray-300: #586069;
+  --amino-gray-400: #6a737d;
+  --amino-gray-500: #959da5;
+  --amino-gray-600: #d1d5da;
+  --amino-gray-700: #e1e4e8;
+  --amino-gray-800: #f6f8fa;
+  --amino-gray-900: #fafbfc;
 
   --amino-backdrop-color: var(--amino-gray-200);
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -101,6 +101,7 @@
   --amino-appbar-height: 64px;
   --amino-sidebar-width: 219px;
   --amino-sidebar-color: white;
+  --amino-backdrop-color: var(--amino-gray-900);
 
   --amino-elevation-0: 0;
   --amino-elevation-100: 100;
@@ -151,4 +152,28 @@
       "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
       "Droid Sans", "Helvetica Neue", sans-serif;
   }
+}
+
+[data-theme="dark"] {
+  --amino-gray-50: #171e2e;
+  --amino-gray-100: #252f3f;
+  --amino-gray-200: #374151;
+  --amino-gray-300: #4b5563;
+  --amino-gray-400: #6b7280;
+  --amino-gray-500: #9fa6b2;
+  --amino-gray-600: #d2d6dc;
+  --amino-gray-700: #e5e7eb;
+  --amino-gray-800: #f4f5f7;
+  --amino-gray-900: #f9fafb;
+
+  --amino-backdrop-color: var(--amino-gray-200);
+
+  --amino-surface-color: var(--amino-gray-100);
+  --amino-surface-color-secondary: var(--amino-gray-50);
+  --amino-border-color: var(--amino-gray-200);
+  --amino-text-color: white;
+  --amino-input-background: var(--amino-gray-300);
+  --amino-hover-color: var(--amino-gray-400);
+
+  --amino-border: 1px solid var(--amino-border-color);
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -155,7 +155,17 @@
 }
 
 [data-theme="dark"] {
-  --amino-gray-50: #24292e;
+  --amino-gray-50: #0d1117;
+  --amino-gray-100: #161b22;
+  --amino-gray-200: #21262d;
+  --amino-gray-300: #30363d;
+  --amino-gray-400: #484f58;
+  --amino-gray-500: #6e7681;
+  --amino-gray-600: #8b949e;
+  --amino-gray-700: #b1bac4;
+  --amino-gray-800: #c9d1d9;
+  --amino-gray-900: #f0f6fc;
+  /* --amino-gray-50: #24292d;
   --amino-gray-100: #2f363d;
   --amino-gray-200: #444d56;
   --amino-gray-300: #586069;
@@ -164,7 +174,7 @@
   --amino-gray-600: #d1d5da;
   --amino-gray-700: #e1e4e8;
   --amino-gray-800: #f6f8fa;
-  --amino-gray-900: #fafbfc;
+  --amino-gray-900: #fafbfc; */
 
   --amino-backdrop-color: var(--amino-gray-200);
   --amino-page-background: var(--amino-gray-50);

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -165,16 +165,6 @@
   --amino-gray-700: #b1bac4;
   --amino-gray-800: #c9d1d9;
   --amino-gray-900: #f0f6fc;
-  /* --amino-gray-50: #24292d;
-  --amino-gray-100: #2f363d;
-  --amino-gray-200: #444d56;
-  --amino-gray-300: #586069;
-  --amino-gray-400: #6a737d;
-  --amino-gray-500: #959da5;
-  --amino-gray-600: #d1d5da;
-  --amino-gray-700: #e1e4e8;
-  --amino-gray-800: #f6f8fa;
-  --amino-gray-900: #fafbfc; */
 
   --amino-backdrop-color: var(--amino-gray-200);
   --amino-page-background: var(--amino-gray-50);

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,7 +1,7 @@
 :root {
   --amino-transition: all 0.2s ease-in-out 0s;
 
-  --amino-type-scale-base: 13px;
+  --amino-type-scale-base: 14px;
 
   --amino-text-xxxxl: 3.815em;
   --amino-text-xxxl: 3.052em;
@@ -167,13 +167,13 @@
   --amino-gray-900: #fafbfc;
 
   --amino-backdrop-color: var(--amino-gray-200);
-
+  --amino-page-background: var(--amino-gray-50);
   --amino-surface-color: var(--amino-gray-100);
   --amino-surface-color-secondary: var(--amino-gray-50);
   --amino-border-color: var(--amino-gray-200);
   --amino-text-color: white;
   --amino-input-background: var(--amino-gray-300);
   --amino-hover-color: var(--amino-gray-400);
-  --amino-sidebar-color: vaR(--amino-gray-50);
+  --amino-sidebar-color: vaR(--amino-gray-100);
   --amino-border: 1px solid var(--amino-border-color);
 }


### PR DESCRIPTION
First part of actual dark mode support! Let me know thoughts on this implementation of a wrapper component that forces specific sections to dark mode as well. Dark mode currently only applies to specific elements with the `data-theme="dark"` property, not following system behavior. So merging won't break anything since we aren't ready to deploy full dark mode any time soon. Additionally, I will send a follow up PR to remove references to `AminoTheme.ts`

Pic of `<DarkModeWrapper />` in action:
<img width="937" alt="CleanShot 2021-03-08 at 18 18 16@2x" src="https://user-images.githubusercontent.com/926065/110403871-19404400-803b-11eb-9d74-ad4af50e4426.png">

Video of full dark mode in action:

https://user-images.githubusercontent.com/926065/110404003-51478700-803b-11eb-8429-64f23055145a.mov


