### PR TITLE
fix(hstack): inferred columns

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,5 +4,15 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-a11y"
-  ]
+  ],
+  typescript: {
+    check: false,
+    checkOptions: {},
+    reactDocgen: "react-docgen-typescript",
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      propFilter: prop =>
+        prop.parent ? !/node_modules/.test(prop.parent.fileName) : true
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "2.74.0",
+  "version": "2.75.0",
   "description": "Core UI components for Amino",
   "main": "dist/index.js",
   "repository": "git@github.com:amino-ui/core.git",

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -59,11 +59,11 @@ const SelectWrapper = styled.div`
 export type SelectProps = {
   autoFocus?: boolean;
   items: Array<any>;
-  label: string | null;
+  label?: string | null;
   helpText?: string;
   onChange: (newValue: string) => any;
   value: string;
-  placeholder: string;
+  placeholder?: string;
   itemLabelPath?: string;
   itemValuePath?: string;
   labelFormatFunction?: any;
@@ -115,7 +115,9 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             tabIndex={tabIndex}
             value={value}
           >
-            {!required && <option value="">{placeholder}</option>}
+            {!required && placeholder && (
+              <option value="">{placeholder}</option>
+            )}
             {items.map((item: any, index: number) => (
               <option
                 key={`${getItemLabel(index)}-${index}`}

--- a/src/components/Stack/HStack.ts
+++ b/src/components/Stack/HStack.ts
@@ -1,7 +1,11 @@
 import styled from "styled-components";
 
-import { AminoTheme } from "../../styles/AminoTheme";
 import { GridAlignment, GridSpacing } from ".";
+
+export type HStackProps = {
+  alignment?: GridAlignment;
+  spacing?: GridSpacing;
+};
 
 /**
  * A horizontal stack
@@ -9,17 +13,14 @@ import { GridAlignment, GridSpacing } from ".";
  * @param alignment - Optional alignment
  * @param spacing - Optional spacing between elements
  */
-export const HStack = styled.div<{
-  alignment?: GridAlignment;
-  spacing?: GridSpacing;
-}>`
+export const HStack = styled.div<HStackProps>`
   display: grid;
-  grid-auto-columns: auto;
+  grid-auto-columns: minmax(0, 1fr);
   column-gap: ${p =>
-    p.spacing ? `var(--amino-${p.spacing})` : `var(${AminoTheme.space})`};
+    p.spacing ? `var(--amino-${p.spacing})` : `var(--amino-space)`};
   grid-auto-flow: column;
 
   & > * {
-    justify-self: ${p => (p.alignment === "end" ? "end" : "unset")};
+    justify-self: ${p => p.alignment || "unset"};
   }
 `;

--- a/src/components/Stack/index.ts
+++ b/src/components/Stack/index.ts
@@ -1,6 +1,6 @@
 export { Stack, StackType } from "./Stack";
 export { VStack } from "./VStack";
-export { HStack } from "./HStack";
+export { HStack, HStackProps } from "./HStack";
 
 export type GridAlignment = "start" | "end";
 export type GridSpacing =

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export { DataList } from "./components/DataList";
 export { Tabs } from "./components/Tabs";
 
 export { VStack } from "./components/Stack";
-export { HStack } from "./components/Stack";
+export { HStack, HStackProps } from "./components/Stack";
 
 export { AminoTheme } from "./styles/AminoTheme";
 export { DarkModeWrapper } from "./components/DarkModeWrapper";

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -3,10 +3,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import { Button, ButtonProps } from "../components/Button";
 
-export default {
+const ButtonMeta: Meta = {
   title: "Amino/Button",
   component: Button
-} as Meta;
+};
+
+export default ButtonMeta;
 
 const Template: Story<ButtonProps> = args => <Button {...args} />;
 

--- a/src/stories/Card.stories.tsx
+++ b/src/stories/Card.stories.tsx
@@ -4,10 +4,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 import { Card, CardProps } from "../components/Card";
 import { Button } from "../components/Button";
 
-export default {
+const CardMeta: Meta = {
   title: "Amino/Card",
   component: Card
-} as Meta;
+};
+
+export default CardMeta;
 
 const Template: Story<CardProps> = args => <Card {...args} />;
 

--- a/src/stories/Checkbox.stories.tsx
+++ b/src/stories/Checkbox.stories.tsx
@@ -3,10 +3,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import { Checkbox, CheckboxProps } from "../components/Checkbox";
 
-export default {
+const CheckboxMeta: Meta = {
   title: "Amino/Checkbox",
   component: Checkbox
-} as Meta;
+};
+
+export default CheckboxMeta;
 
 const Template: Story<CheckboxProps> = args => <Checkbox {...args} />;
 

--- a/src/stories/Combobox.stories.tsx
+++ b/src/stories/Combobox.stories.tsx
@@ -3,10 +3,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import { Combobox, ComboboxProps } from "../components/Combobox";
 
-export default {
+const ComboboxMeta: Meta = {
   title: "Amino/Combobox",
   component: Combobox
-} as Meta;
+};
+
+export default ComboboxMeta;
 
 const Template: Story<ComboboxProps> = args => <Combobox {...args} />;
 

--- a/src/stories/DarkModeWrapper.stories.tsx
+++ b/src/stories/DarkModeWrapper.stories.tsx
@@ -8,10 +8,12 @@ import {
 
 import { Card } from "../components/Card";
 
-export default {
+const DarkModeWrapperMeta: Meta = {
   title: "Amino/DarkModeWrapper",
   component: DarkModeWrapper
-} as Meta;
+};
+
+export default DarkModeWrapperMeta;
 
 const Template: Story<DarkModeWrapperProps> = args => (
   <DarkModeWrapper>

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -3,10 +3,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import { Input, InputProps } from "../components/Input";
 
-export default {
+const InputMeta: Meta = {
   title: "Amino/Input",
   component: Input
-} as Meta;
+};
+
+export default InputMeta;
 
 const Template: Story<InputProps> = args => <Input {...args} />;
 

--- a/src/stories/MenuButton.stories.tsx
+++ b/src/stories/MenuButton.stories.tsx
@@ -3,10 +3,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import { MenuButton, MenuButtonProps } from "../components/Button";
 
-export default {
+const MenuButtonMeta: Meta = {
   title: "Amino/MenuButton",
   component: MenuButton
-} as Meta;
+};
+
+export default MenuButtonMeta;
 
 const Template: Story<MenuButtonProps> = args => <MenuButton {...args} />;
 

--- a/src/stories/Notice.stories.tsx
+++ b/src/stories/Notice.stories.tsx
@@ -3,10 +3,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import { Notice, NoticeProps } from "../components/Notice";
 
-export default {
+const NoticeStories: Meta = {
   title: "Amino/Notice",
   component: Notice
-} as Meta;
+};
+
+export default NoticeStories;
 
 const Template: Story<NoticeProps> = args => <Notice {...args} />;
 

--- a/src/stories/Radio.stories.tsx
+++ b/src/stories/Radio.stories.tsx
@@ -3,10 +3,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import { Radio, RadioProps } from "../components/Radio";
 
-export default {
+const RadioMeta: Meta = {
   title: "Amino/Radio",
   component: Radio
-} as Meta;
+};
+
+export default RadioMeta;
 
 const Template: Story<RadioProps> = args => <Radio {...args} />;
 

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -3,10 +3,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import { Select, SelectProps } from "../components/Select";
 
-export default {
+const SelectMeta: Meta = {
   title: "Amino/Select",
   component: Select
-} as Meta;
+};
+
+export default SelectMeta;
 
 const Template: Story<SelectProps> = args => <Select {...args} />;
 

--- a/src/stories/Skeleton.stories.tsx
+++ b/src/stories/Skeleton.stories.tsx
@@ -3,10 +3,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import { Skeleton, SkeletonProps } from "../components/Skeleton";
 
-export default {
+const SkeletonMeta: Meta = {
   title: "Amino/Skeleton",
   component: Skeleton
-} as Meta;
+};
+
+export default SkeletonMeta;
 
 const Template: Story<SkeletonProps> = args => <Skeleton {...args} />;
 

--- a/src/stories/Spinner.stories.tsx
+++ b/src/stories/Spinner.stories.tsx
@@ -3,10 +3,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import { Spinner, SpinnerProps } from "../components/Spinner";
 
-export default {
+const SpinnerMeta: Meta = {
   title: "Amino/Spinner",
   component: Spinner
-} as Meta;
+};
+
+export default SpinnerMeta;
 
 const Template: Story<SpinnerProps> = args => <Spinner {...args} />;
 

--- a/src/stories/Stack/HStack.stories.tsx
+++ b/src/stories/Stack/HStack.stories.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react/types-6-0";
+
+import { Select, SelectProps } from "../../components/Select";
+import { HStack, HStackProps } from "../../components/Stack";
+
+const HStackMeta: Meta = {
+  title: "Amino/HStack",
+  component: HStack,
+  subcomponents: { Select }
+};
+
+export default HStackMeta;
+
+const Template: Story<HStackProps> = args => (
+  <HStack {...args}>
+    <Select
+      label="Frankfurters"
+      helpText="When you go to a ballgame..."
+      items={[]}
+      onChange={() => {}}
+      value=""
+    />
+
+    <Select
+      label="HotDogs"
+      helpText="If you are a fan."
+      items={[]}
+      onChange={() => {}}
+      value=""
+    />
+  </HStack>
+);
+
+export const HStackSelects = Template.bind({});
+HStackSelects.args = {
+  spacing: "space"
+};

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -3,10 +3,12 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import { Tabs, TabsProps } from "../components/Tabs";
 
-export default {
+const TabsMeta: Meta = {
   title: "Amino/Tabs",
   component: Tabs
-} as Meta;
+};
+
+export default TabsMeta;
 
 const Template: Story<TabsProps> = args => <Tabs {...args} />;
 


### PR DESCRIPTION
This PR fixes a problem with HStack inferred auto columns. The fix was found at css-tricks https://css-tricks.com/equal-width-columns-in-css-grid-are-kinda-weird/

This PR also avoids type-casting in the stories.

