### PR TITLE
Add Alert dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "2.112.0",
+  "version": "2.113.0",
   "description": "Core UI components for Amino",
   "main": "dist/index.js",
   "module": "dist/index.esm/js",

--- a/src/components/AlertDialog/AlertContext.tsx
+++ b/src/components/AlertDialog/AlertContext.tsx
@@ -1,0 +1,40 @@
+import React, { useState, createContext, ReactNode } from 'react';
+
+import { AlertDialogOpts } from 'types';
+
+import { AlertDialog } from './AlertDialog';
+
+export const AlertContext = createContext((opts: AlertDialogOpts) => {});
+
+type Props = {
+  children: ReactNode;
+};
+
+export const AlertContextProvider = ({ children }: Props) => {
+  const [dialog, setDialog] = useState<AlertDialogOpts | null>();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const confirm = (opts: AlertDialogOpts) => {
+    setDialog(opts);
+    setIsOpen(true);
+  };
+
+  return (
+    <AlertContext.Provider value={confirm}>
+      {children}
+      {dialog && (
+        <AlertDialog
+          open={isOpen}
+          label={dialog.label}
+          subtitle={dialog.subtitle}
+          intent={dialog.intent}
+          dismissText={dialog.dismissText}
+          dismissAction={() => {
+            setIsOpen(false);
+            dialog.onDismiss();
+          }}
+        />
+      )}
+    </AlertContext.Provider>
+  );
+};

--- a/src/components/AlertDialog/AlertDialog.tsx
+++ b/src/components/AlertDialog/AlertDialog.tsx
@@ -8,7 +8,7 @@ import { BaseDialog } from '../Dialog/BaseDialog';
 import { Button } from '../Button';
 import { RoundedIcon } from '../RoundedIcon';
 import { VStack } from '../Stack';
-import { DangerIcon, HelpIcon } from '../../icons';
+import { DangerIcon, InfoIcon } from '../../icons';
 
 const Content = styled.div`
   padding: var(--amino-space);
@@ -37,19 +37,17 @@ const Footer = styled.div`
   }
 `;
 
-const ConfirmationPrompt = styled.span`
+const AlertPrompt = styled.span`
   opacity: 0.5;
 `;
 
-export type ConfirmDialogProps = {
+export type AlertDialogProps = {
   open: boolean;
   label: string;
   theme?: IAminoTheme;
   subtitle: React.ReactNode;
   intent: Intent;
-  confirmText: string;
   dismissText: string;
-  confirmAction: () => void;
   dismissAction: () => void;
 };
 
@@ -59,34 +57,29 @@ const getIconForIntent = (intent: Intent) => {
       return <DangerIcon />;
     case 'info':
     default:
-      return <HelpIcon />;
+      return <InfoIcon />;
   }
 };
 
-export const ConfirmDialog = ({
+export const AlertDialog = ({
   theme,
   open,
   label,
   intent,
   subtitle,
-  confirmText,
   dismissText,
-  confirmAction,
   dismissAction,
-}: ConfirmDialogProps) => (
+}: AlertDialogProps) => (
   <BaseDialog width={350} data-theme={theme} open={open}>
     <Content>
       <VStack spacing="space-half">
         <RoundedIcon intent={intent}>{getIconForIntent(intent)}</RoundedIcon>
         <div>
           <Text type="h4">{label}</Text>
-          <ConfirmationPrompt>{subtitle}</ConfirmationPrompt>
+          <AlertPrompt>{subtitle}</AlertPrompt>
         </div>
         <Footer>
           <Button onClick={dismissAction}>{dismissText}</Button>
-          <Button onClick={confirmAction} intent={intent}>
-            {confirmText}
-          </Button>
         </Footer>
       </VStack>
     </Content>

--- a/src/components/AlertDialog/index.ts
+++ b/src/components/AlertDialog/index.ts
@@ -1,0 +1,2 @@
+export { AlertDialog, AlertDialogProps } from './AlertDialog';
+export { AlertContext, AlertContextProvider } from './AlertContext';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useConfirm } from './useConfirm';
 export { useInputValue } from './useInputValue';
 export { useCheckboxValue } from './useCheckboxValue';
+export { useAlert } from './useAlert';

--- a/src/hooks/useAlert.ts
+++ b/src/hooks/useAlert.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import { AlertContext } from 'components/AlertDialog';
+
+export const useAlert = () => {
+  return useContext(AlertContext);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,14 +21,16 @@ export {
   ConfirmContextProvider,
   ConfirmContext,
 } from './components/ConfirmDialog';
+export {
+  AlertDialog,
+  AlertContextProvider,
+  AlertContext,
+} from './components/AlertDialog';
 
 export { Spinner } from './components/Spinner';
 export { Skeleton } from './components/Skeleton';
 
 export { Depth, Surface, Intent } from './types';
-
-export { useInputValue } from './hooks/useInputValue';
-export { useCheckboxValue } from './hooks/useCheckboxValue';
 
 export { DropdownAnimation, DropdownAnimationInverse } from './animations';
 
@@ -44,3 +46,4 @@ export { RoundedIcon } from './components/RoundedIcon';
 export { TextAvatar } from './components/TextAvatar';
 
 export * from './icons';
+export * from './hooks';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,17 @@ export { List } from './components/List';
 export { Dialog } from './components/Dialog';
 export { Toast, ToastContextProvider, ToastContext } from './components/Toast';
 export { Menu, MenuItem } from './components/Menu';
+export { Spinner } from './components/Spinner';
+export { Skeleton } from './components/Skeleton';
+export { Tabs } from './components/Tabs';
+export { VStack } from './components/Stack';
+export { HStack, HStackProps } from './components/Stack';
+export { DarkModeWrapper } from './components/DarkModeWrapper';
+export { DangerZone } from './components/DangerZone';
+export { RichRadio } from './components/RichRadio';
+export { RoundedIcon } from './components/RoundedIcon';
+export { TextAvatar } from './components/TextAvatar';
+
 export {
   ConfirmDialog,
   ConfirmContextProvider,
@@ -27,23 +38,8 @@ export {
   AlertContext,
 } from './components/AlertDialog';
 
-export { Spinner } from './components/Spinner';
-export { Skeleton } from './components/Skeleton';
-
-export { Depth, Surface, Intent } from './types';
-
-export { DropdownAnimation, DropdownAnimationInverse } from './animations';
-
-export { Tabs } from './components/Tabs';
-
-export { VStack } from './components/Stack';
-export { HStack, HStackProps } from './components/Stack';
-
-export { DarkModeWrapper } from './components/DarkModeWrapper';
-export { DangerZone } from './components/DangerZone';
-export { RichRadio } from './components/RichRadio';
-export { RoundedIcon } from './components/RoundedIcon';
-export { TextAvatar } from './components/TextAvatar';
-
 export * from './icons';
 export * from './hooks';
+export * from './types';
+
+export { DropdownAnimation, DropdownAnimationInverse } from './animations';

--- a/src/stories/AlertDialog/AlertConsumer.tsx
+++ b/src/stories/AlertDialog/AlertConsumer.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { useAlert } from 'hooks';
+import { Button, VStack } from '../..';
+
+export const AlertConsumer = () => {
+  const defaultAlert = useAlert();
+  const dangerAlert = useAlert();
+
+  return (
+    <VStack>
+      <Button
+        onClick={() =>
+          defaultAlert({
+            label: 'Heads up',
+            subtitle: 'You look nice today',
+            intent: 'primary',
+            dismissText: 'OK',
+            onDismiss: () => {},
+          })
+        }
+      >
+        Trigger default alert
+      </Button>
+      <Button
+        onClick={() =>
+          dangerAlert({
+            label: 'Heads up',
+            subtitle: 'There was an error or something',
+            intent: 'danger',
+            dismissText: 'OK',
+            onDismiss: () => {},
+          })
+        }
+      >
+        Trigger danger alert
+      </Button>
+    </VStack>
+  );
+};

--- a/src/stories/AlertDialog/AlertDialogProvider.stories.tsx
+++ b/src/stories/AlertDialog/AlertDialogProvider.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { withDesign } from 'storybook-addon-designs';
+
+import { AlertContextProvider } from '../..';
+import { AlertConsumer } from './AlertConsumer';
+
+const AlertContextProviderMeta: Meta = {
+  title: 'Amino/AlertContextProvider',
+  component: AlertContextProvider,
+  decorators: [withDesign],
+};
+
+export default AlertContextProviderMeta;
+
+const Template: Story = () => (
+  <AlertContextProvider>
+    <AlertConsumer />
+  </AlertContextProvider>
+);
+
+export const DefaultAlert = Template.bind({});
+DefaultAlert.parameters = {
+  design: {
+    type: 'figma',
+    url:
+      'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=279%3A34',
+  },
+};

--- a/src/types/AlertDialogOpts.ts
+++ b/src/types/AlertDialogOpts.ts
@@ -1,0 +1,9 @@
+import { Intent } from './Intent';
+
+export type AlertDialogOpts = {
+  label: string;
+  subtitle: string;
+  intent: Intent;
+  dismissText: string;
+  onDismiss: () => void;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,4 @@ export type { IAminoTheme } from './IAminoTheme';
 export type { ConfirmDialogOpts } from './ConfirmDialogOpts';
 export type { Color } from './Color';
 export type { IconProps } from './IconProps';
+export type { AlertDialogOpts } from './AlertDialogOpts';


### PR DESCRIPTION
Adds `<AlertDialog/>` and `useAlert` hook for easy access.

See example here: https://amino-ui-git-feat-alert-dialog-zonos.vercel.app/?path=/story/amino-alertcontextprovider--default-alert

Additionally cleans up the export of Amino's provided hooks.