### PR TITLE
feat(card): add footer height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "2.120.0",
+  "version": "2.121.0",
   "description": "Core UI components for Amino",
   "main": "dist/index.js",
   "module": "dist/index.esm/js",

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -23,7 +23,7 @@ const CardHeader = styled.header`
   }
 `;
 
-const CardFooter = styled.footer`
+const CardFooter = styled.footer<{ footerHeight?: number }>`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -34,23 +34,26 @@ const CardFooter = styled.footer`
   margin-top: var(--amino-space);
   border-bottom-left-radius: var(--amino-radius-lg);
   border-bottom-right-radius: var(--amino-radius-lg);
+  height: ${p => p.footerHeight && `${p.footerHeight}px`};
 `;
 
 export type CardProps = {
   actions?: React.ReactNode;
-  className?: string;
-  label?: React.ReactNode;
-  footerContent?: React.ReactNode;
-  footerActions?: React.ReactNode;
   children: React.ReactNode;
+  className?: string;
+  footerActions?: React.ReactNode;
+  footerContent?: React.ReactNode;
+  footerHeight?: number;
+  label?: React.ReactNode;
 };
 
 export const Card = ({
   actions,
   children,
   className,
-  footerContent,
   footerActions,
+  footerContent,
+  footerHeight,
   label,
 }: CardProps) => {
   return (
@@ -64,7 +67,7 @@ export const Card = ({
       )}
       {children}
       {(footerActions || footerContent) && (
-        <CardFooter>
+        <CardFooter footerHeight={footerHeight}>
           <div>{footerContent}</div>
           <HStack spacing="space-quarter">{footerActions}</HStack>
         </CardFooter>

--- a/src/stories/Card.stories.tsx
+++ b/src/stories/Card.stories.tsx
@@ -14,17 +14,19 @@ const CardMeta: Meta = {
 export default CardMeta;
 
 const Template: Story<CardProps> = ({
-  label,
-  children,
   actions,
-  footerContent,
+  children,
   footerActions,
+  footerContent,
+  footerHeight,
+  label,
 }: CardProps) => (
   <Card
-    label={label}
     actions={actions}
     footerActions={footerActions}
     footerContent={footerContent}
+    footerHeight={footerHeight}
+    label={label}
   >
     {children}
   </Card>
@@ -71,6 +73,35 @@ CardWithFooter.args = {
   ),
 };
 CardWithFooter.parameters = {
+  design: {
+    type: 'figma',
+    url:
+      'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A34',
+  },
+};
+
+export const CardWithFooterWithoutFooterActions = Template.bind({});
+CardWithFooterWithoutFooterActions.args = {
+  children: 'content',
+  label: 'Super cool',
+  footerContent: 'footer content',
+};
+CardWithFooterWithoutFooterActions.parameters = {
+  design: {
+    type: 'figma',
+    url:
+      'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A34',
+  },
+};
+
+export const CardWithFooterHeight = Template.bind({});
+CardWithFooterHeight.args = {
+  children: 'content',
+  label: 'Super cool',
+  footerContent: 'footer content',
+  footerHeight: 120,
+};
+CardWithFooterHeight.parameters = {
   design: {
     type: 'figma',
     url:


### PR DESCRIPTION
## Description
This PR adds a card footer height to help cards in HStacks line-up better: 
<img width="825" alt="Screen Shot 2021-06-11 at 4 48 15 PM" src="https://user-images.githubusercontent.com/12107173/121755601-d4fa8f00-cad4-11eb-9627-e8707209022e.png">
