### PR TITLE
fix(card): make children stretch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "2.121.0",
+  "version": "2.122.0",
   "description": "Core UI components for Amino",
   "main": "dist/index.js",
   "module": "dist/index.esm/js",

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -37,6 +37,12 @@ const CardFooter = styled.footer<{ footerHeight?: number }>`
   height: ${p => p.footerHeight && `${p.footerHeight}px`};
 `;
 
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: space-between;
+`;
+
 export type CardProps = {
   actions?: React.ReactNode;
   children: React.ReactNode;
@@ -58,20 +64,22 @@ export const Card = ({
 }: CardProps) => {
   return (
     <Surface depth={Depth.depth4} className={className || ''}>
-      {label && (
-        <CardHeader>
-          <Text type="h4">{label}</Text>
+      <StyledWrapper>
+        {label && (
+          <CardHeader>
+            <Text type="h4">{label}</Text>
 
-          <HStack spacing="space-quarter">{actions}</HStack>
-        </CardHeader>
-      )}
-      {children}
-      {(footerActions || footerContent) && (
-        <CardFooter footerHeight={footerHeight}>
-          <div>{footerContent}</div>
-          <HStack spacing="space-quarter">{footerActions}</HStack>
-        </CardFooter>
-      )}
+            <HStack spacing="space-quarter">{actions}</HStack>
+          </CardHeader>
+        )}
+        {children}
+        {(footerActions || footerContent) && (
+          <CardFooter footerHeight={footerHeight}>
+            <div>{footerContent}</div>
+            <HStack spacing="space-quarter">{footerActions}</HStack>
+          </CardFooter>
+        )}
+      </StyledWrapper>
     </Surface>
   );
 };


### PR DESCRIPTION
## Description
This PR makes the card children stretch instead of moving the footer around. It should fix: 
<img width="410" alt="Screen Shot 2021-06-11 at 5 13 23 PM" src="https://user-images.githubusercontent.com/12107173/121756740-661f3500-cad8-11eb-9202-290734566fad.png">
