### PR TITLE
feat(text): add title prop, story for Text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "2.123.0",
+  "version": "2.124.0",
   "description": "Core UI components for Amino",
   "main": "dist/index.js",
   "module": "dist/index.esm/js",

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -36,32 +36,34 @@ type TextStyle =
   | 'smallheader'
   | 'inputlabel';
 
-type Props = {
+export type TextProps = {
+  children: React.ReactNode;
+  title?: string;
   type?: TextStyle;
 };
 
-export const Text: React.FC<Props> = ({ children, type }) => {
+export const Text: React.FC<TextProps> = ({ children, title, type }) => {
   switch (type) {
     case 'h1':
-      return <h1>{children}</h1>;
+      return <h1 title={title}>{children}</h1>;
     case 'h2':
-      return <h2>{children}</h2>;
+      return <h2 title={title}>{children}</h2>;
     case 'h3':
-      return <h3>{children}</h3>;
+      return <h3 title={title}>{children}</h3>;
     case 'h4':
-      return <h4>{children}</h4>;
+      return <h4 title={title}>{children}</h4>;
     case 'h5':
-      return <h5>{children}</h5>;
+      return <h5 title={title}>{children}</h5>;
     case 'h6':
-      return <h6>{children}</h6>;
+      return <h6 title={title}>{children}</h6>;
     case 'subtitle':
-      return <Subtitle>{children}</Subtitle>;
+      return <Subtitle title={title}>{children}</Subtitle>;
     case 'smallheader':
-      return <SmallHeader>{children}</SmallHeader>;
+      return <SmallHeader title={title}>{children}</SmallHeader>;
     case 'inputlabel':
-      return <InputLabel>{children}</InputLabel>;
+      return <InputLabel title={title}>{children}</InputLabel>;
     case 'p':
     default:
-      return <p>{children}</p>;
+      return <p title={title}>{children}</p>;
   }
 };

--- a/src/components/Text/index.ts
+++ b/src/components/Text/index.ts
@@ -1,1 +1,1 @@
-export { Text } from './Text';
+export { Text, TextProps } from './Text';

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { withDesign } from 'storybook-addon-designs';
+
+import { Text, TextProps } from '../components/Text';
+
+const TextMeta: Meta = {
+  title: 'Amino/Text',
+  component: Text,
+  decorators: [withDesign],
+};
+
+export default TextMeta;
+
+const Template: Story<TextProps> = ({ children, title, type }: TextProps) => (
+  <Text type={type} title={title}>
+    {children}
+  </Text>
+);
+
+export const H1Text = Template.bind({});
+H1Text.args = {
+  type: 'h1',
+  children: 'Hello I am an h1',
+};
+H1Text.parameters = {
+  design: {
+    type: 'figma',
+    url:
+      'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A122',
+  },
+};
+
+export const H1TextWithTitle = Template.bind({});
+H1TextWithTitle.args = {
+  title: 'You found me',
+  type: 'h1',
+  children: 'Hello I am an h1 with a title',
+};
+H1TextWithTitle.parameters = {
+  design: {
+    type: 'figma',
+    url:
+      'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A122',
+  },
+};


### PR DESCRIPTION
### Jira

N/A

### Description

This PR adds a ```title``` prop/attribute to the ```Text``` component to allow for accessibility even when instances of ```Text``` are truncated due to length. 