### PR TITLE
Fix/appbar height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "2.125.0",
+  "version": "2.126.0",
   "description": "Core UI components for Amino",
   "main": "dist/index.js",
   "module": "dist/index.esm/js",

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -42,7 +42,7 @@ const Sidebar = styled.nav<{ hasHeader: boolean }>`
   box-sizing: border-box;
   background: white;
   display: grid;
-  grid-template-rows: 1fr calc(38px + var(--amino-space) * 2);
+  grid-template-rows: 1fr calc(39px + var(--amino-space) * 2);
   background: var(--amino-sidebar-color);
 `;
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -42,7 +42,7 @@ const Sidebar = styled.nav<{ hasHeader: boolean }>`
   box-sizing: border-box;
   background: white;
   display: grid;
-  grid-template-rows: 1fr var(--amino-appbar-height);
+  grid-template-rows: 1fr calc(38px + var(--amino-space) * 2);
   background: var(--amino-sidebar-color);
 `;
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -124,7 +124,7 @@
   --amino-text-dark: var(--amino-text-color);
 
   --amino-input-background: white;
-  --amino-appbar-height: calc(38px + var(--amino-space) * 2);
+  --amino-appbar-height: 55px;
   --amino-sidebar-width: 219px;
   --amino-sidebar-color: var(--amino-page-background);
   --amino-header-color: white;


### PR DESCRIPTION
### Jira

N/A

### Description

This PR fixes some visual jank introduced in the last version. I was confused a bit by the usage of appbar-height in multiple contexts, which led to a somewhat erroneous change. This PR corrects and implements a fix, accounting for the previous height ```amino-appbar-height``` was set to in Dashboard (55px), and eliminates the potentially confusing usage of ```amino-appbar-height``` when formatting the grid for the SidebarContent and instead use the calculated height agreed upon within dashboard-web for ```UserMenu```. 