### PR TITLE
fix(slider): change position of indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "2.133.0",
+  "version": "2.134.0",
   "description": "Core UI components for Amino",
   "main": "dist/index.js",
   "module": "dist/index.esm/js",

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -50,7 +50,7 @@ const SliderWrapper = styled.div`
 `;
 
 const Indicator = styled.div`
-  position: absolute;
+  position: relative;
   background: var(--amino-blue-100);
   color: var(--amino-blue-700);
   width: 48px;


### PR DESCRIPTION
### Jira

N/A

### Description

This PR changes the position of the the Indicator to relative, as setting it to absolute was causing some height calculation problems in Dashboard and as I want to avoid hard-coded heights, changed the Indicator position to relative to place the Indicator back into the document flow. 

### Before
![image](https://user-images.githubusercontent.com/57578761/124995780-1e22fd80-e005-11eb-931b-788f3166095c.png)

Setting the position to relative should place the Indicator back into the document flow and have it be factored into height calculations and avoid unnecessary overflow for this and other cases. 