### PR TITLE
Fix Rich Radio visual jankiness for long labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "2.162.0",
+  "version": "2.163.0",
   "description": "Core UI components for Amino",
   "main": "dist/index.js",
   "module": "dist/index.esm/js",

--- a/src/components/RichRadio/RichRadio.tsx
+++ b/src/components/RichRadio/RichRadio.tsx
@@ -7,10 +7,11 @@ import { VStack } from 'components/Stack';
 import { CheckIcon } from 'icons';
 
 const StyledItem = styled(Item)`
+  position: relative;
   appearance: none;
-  display: block;
   background: white;
   padding: var(--amino-space-half);
+  padding-right: var(--amino-space-double);
   border: var(--amino-border);
   border-radius: var(--amino-radius);
   text-align: left;
@@ -49,6 +50,8 @@ const StyledRoot = styled(Root)`
 `;
 
 const StyledIndicator = styled(Indicator)`
+  position: absolute;
+  right: var(--amino-space-half);
   background: var(--amino-blue-300);
   content: ' ';
   border-radius: 50px;
@@ -74,20 +77,13 @@ type RichRadioItemType = {
 export type RichRadioProps = {
   onChange: (newVal: string) => void;
   items: RichRadioItemType[];
-  value?: string;
-  defaultValue?: string;
+  value: string;
 };
 
-export const RichRadio = ({
-  defaultValue,
-  value,
-  onChange,
-  items,
-}: RichRadioProps) => (
+export const RichRadio = ({ onChange, items, value }: RichRadioProps) => (
   <StyledRoot
-    defaultValue={defaultValue}
-    value={value}
     onValueChange={e => onChange(e.target.value)}
+    value={value || undefined}
   >
     <VStack spacing="space-half">
       {items.map(item => (

--- a/src/stories/RadioGroup.stories.tsx
+++ b/src/stories/RadioGroup.stories.tsx
@@ -25,16 +25,10 @@ const Template: Story<RadioGroupProps<RadioGroupItem>> = ({
   <RadioGroup initialValue={initialValue} onChange={onChange} items={items} />
 );
 
-export const SimpleRadioGroup: {
-  args: RadioGroupProps<RadioGroupItem>;
-  parameters: {
-    design: {
-      type: string;
-      url: string;
-    };
-  };
-} = Template.bind({});
-SimpleRadioGroup.args = {
+export const SimpleRadioGroup: Story<RadioGroupProps<RadioGroupItem>> =
+  Template.bind({});
+
+const args: RadioGroupProps<RadioGroupItem> = {
   items: [
     {
       value: 'not_for_resale',
@@ -50,9 +44,17 @@ SimpleRadioGroup.args = {
   // eslint-disable-next-line no-console
   onChange: newValue => console.log(newValue),
 };
-SimpleRadioGroup.parameters = {
+const parameters: {
+  design: {
+    type: string;
+    url: string;
+  };
+} = {
   design: {
     type: 'figma',
     url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A122',
   },
 };
+
+SimpleRadioGroup.args = args;
+SimpleRadioGroup.parameters = parameters;

--- a/src/stories/RichCheckbox.stories.tsx
+++ b/src/stories/RichCheckbox.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from '../components/RichCheckboxGroup';
 
 const RichCheckboxMeta: Meta = {
-  title: 'Amino/RichRadio',
+  title: 'Amino/RichCheckboxGroup',
   component: RichCheckboxGroup,
   decorators: [withDesign],
 };

--- a/src/stories/RichRadio.stories.tsx
+++ b/src/stories/RichRadio.stories.tsx
@@ -17,21 +17,16 @@ const Template: Story<RichRadioProps> = ({
   onChange,
   items,
   value,
-  defaultValue,
 }: RichRadioProps) => (
-  <RichRadio
-    defaultValue={defaultValue}
-    value={value}
-    onChange={onChange}
-    items={items}
-  />
+  <RichRadio value={value} onChange={onChange} items={items} />
 );
 
 export const BasicRichRadio = Template.bind({});
 BasicRichRadio.args = {
   items: [
     {
-      label: 'Item 1',
+      label:
+        'Handbags, whether or not with shoulder strap, including those without handle: With outer surface of sheeting of plastics or of textile materials',
       subtitle: 'Item 1 subtitle',
       value: 'item1',
     },
@@ -48,34 +43,6 @@ BasicRichRadio.args = {
   ],
 };
 BasicRichRadio.parameters = {
-  design: {
-    type: 'figma',
-    url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=245%3A181',
-  },
-};
-
-export const DefaultValueRichRadio = Template.bind({});
-DefaultValueRichRadio.args = {
-  items: [
-    {
-      label: 'Item 1',
-      subtitle: 'Item 1 subtitle',
-      value: 'item1',
-    },
-    {
-      label: 'Item 2',
-      subtitle: 'Item 2 subtitle',
-      value: 'item2',
-    },
-    {
-      label: 'Item 3',
-      subtitle: 'Item 3 subtitle',
-      value: 'item3',
-    },
-  ],
-  defaultValue: 'item3',
-};
-DefaultValueRichRadio.parameters = {
   design: {
     type: 'figma',
     url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=245%3A181',


### PR DESCRIPTION


## Description
<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
This PR fixes Rich Radio visual jankiness if the label was long enough to interfere with the checkmark. This PR removes the default value which makes the Rich Radio a controlled component.


## Additional
This PR fixes a typescript issue inside the Storybook.