### PR TITLE
feat(select): fix label design

### DIFF
--- a/src/components/Select/CountryMultiSelect.tsx
+++ b/src/components/Select/CountryMultiSelect.tsx
@@ -93,6 +93,7 @@ export const CountryMultiSelect = ({
       {...props}
       components={{ MenuList }}
       hasGroups
+      hideSelectedOptions={false}
       label={label}
       onChange={changed => onChange(changed as ICountryOption[])}
       options={regionCountryOptions}

--- a/src/components/Select/MultiSelect.tsx
+++ b/src/components/Select/MultiSelect.tsx
@@ -105,7 +105,7 @@ export const MultiSelect = <
   Group extends GroupBase<Option>
 >({
   closeMenuOnSelect = false,
-  hideSelectedOptions = false,
+  hideSelectedOptions = true,
   ...props
 }: MultiSelectProps<Option, true, Group>) => {
   return (

--- a/src/components/Select/StyledReactSelect.tsx
+++ b/src/components/Select/StyledReactSelect.tsx
@@ -17,7 +17,6 @@ import styled from 'styled-components';
 
 import { Checkbox } from 'components/Checkbox';
 import { HelpText } from 'components/HelpText';
-
 import { type HelpTextProps } from 'components/HelpText/HelpText';
 import {
   CheckCircleSolidIcon,

--- a/src/components/Select/StyledReactSelect.tsx
+++ b/src/components/Select/StyledReactSelect.tsx
@@ -18,7 +18,12 @@ import styled from 'styled-components';
 import { Checkbox } from 'components/Checkbox';
 import { HelpText } from 'components/HelpText';
 import { HelpTextProps } from 'components/HelpText/HelpText';
-import { ChevronDownSolidIcon, RemoveCircleSolidIcon, RemoveIcon } from 'icons';
+import {
+  CheckCircleSolidIcon,
+  ChevronDownSolidIcon,
+  RemoveCircleSolidIcon,
+  RemoveIcon,
+} from 'icons';
 
 export type IOption = { icon?: ReactNode; label: string; value: string };
 type AdditionalProps = {
@@ -26,8 +31,6 @@ type AdditionalProps = {
   icon?: ReactNode;
   label?: string;
 };
-
-const SelectWrapper = styled.div``;
 
 const ClearIndicator = <
   Option extends IOption,
@@ -146,30 +149,37 @@ const Control = <
   );
 };
 
-const CheckboxOptionIconWrapper = styled.div`
+const CheckboxOptionIconWrapper = styled.div<{ $color?: string }>`
   display: flex;
   align-items: center;
+  color: ${p => p.$color || 'inherit'};
   svg {
     margin-right: 4px;
+    color: black;
   }
+`;
+
+const SelectedSingleOptionWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 `;
 
 const IconLabel = ({
   children,
+  color,
   icon,
 }: {
   children: ReactNode;
+  color?: string;
   icon?: ReactNode;
 }) => {
-  if (icon) {
-    return (
-      <CheckboxOptionIconWrapper>
-        {icon}
-        {children}
-      </CheckboxOptionIconWrapper>
-    );
-  }
-  return <>{children}</>;
+  return (
+    <CheckboxOptionIconWrapper $color={color}>
+      {icon}
+      {children}
+    </CheckboxOptionIconWrapper>
+  );
 };
 
 const MultiValueLabel = <
@@ -219,22 +229,30 @@ export const CheckboxOptionComponent = <
   } = props;
   const { hasGroups } = selectProps as typeof props['selectProps'] &
     AdditionalProps;
-  const style = getStyles('option', props) as React.CSSProperties;
+  const { color, ...style } = getStyles('option', props) as React.CSSProperties;
   if (hasGroups) {
     style.paddingLeft = 48;
   }
-
   return (
     <div ref={innerRef} style={style} {...innerProps}>
       {selectProps.isMulti ? (
         <Checkbox
           checked={isSelected}
           label={data.value}
-          labelComponent={<IconLabel icon={data.icon}>{children}</IconLabel>}
+          labelComponent={
+            <IconLabel color={color} icon={data.icon}>
+              {children}
+            </IconLabel>
+          }
           onChange={() => {}}
         />
       ) : (
-        <IconLabel icon={data.icon}>{children}</IconLabel>
+        <SelectedSingleOptionWrapper>
+          <IconLabel color={color} icon={data.icon}>
+            {children}
+          </IconLabel>
+          {isSelected && <CheckCircleSolidIcon color="blue-500" size={16} />}
+        </SelectedSingleOptionWrapper>
       )}
     </div>
   );
@@ -312,11 +330,12 @@ const localStyles: StylesConfig<IOption, boolean, GroupBase<IOption>> = {
   // multiValueLabel
   // multiValueRemove
   // noOptionsMessage
-  option: provided => {
+  option: (provided, state) => {
     return {
       ...provided,
       '&:hover': { backgroundColor: 'red' },
-      color: 'black',
+      color: state.isSelected ? 'var(--amino-blue-500)' : 'black',
+      fontWeight: state.isSelected ? 500 : 400,
       backgroundColor: 'inherit',
       paddingTop: 7,
       paddingRight: 12,
@@ -375,7 +394,7 @@ export const StyledReactSelect = <
     label,
   };
   return (
-    <SelectWrapper>
+    <div>
       <ReactSelect<Option, IsMulti, Group>
         components={
           {
@@ -418,6 +437,6 @@ export const StyledReactSelect = <
         {...additionalProps}
       />
       <HelpText error={error} helpText={helpText} />
-    </SelectWrapper>
+    </div>
   );
 };

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -131,3 +131,33 @@ BasicSelectWithIcon.parameters = {
     url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A135',
   },
 };
+
+export const BasicSelectWithOptionIcon = SelectTemplate.bind({});
+
+BasicSelectWithOptionIcon.args = {
+  icon: <FileIcon size={20} />,
+  label: 'Currencies',
+  value: {
+    label: 'US Dollar (USD)',
+    value: 'USD',
+  },
+  options: [
+    {
+      label: 'US Dollar (USD)',
+      icon: <FileIcon size={14} />,
+      value: 'USD',
+    },
+    {
+      icon: <FileIcon size={14} />,
+      label: 'European Euro (EUR)',
+      value: 'EUR',
+    },
+  ],
+};
+
+BasicSelectWithOptionIcon.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A135',
+  },
+};


### PR DESCRIPTION
## Jira issue
<!-- [Jira issue description](url) -->
<!-- Example:
[3106 - Loup Charmant - Need dashboard switched from Hello](https://myzonos.atlassian.net/browse/DM-550)
-->
[Amino 3 - Country select](https://myzonos.atlassian.net/browse/BBT-515?focusedCommentId=55686)

## Description
<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
This PR fixes the select label design to have the selected item blue for single selects with a checkmark to the far right. In addition to defaulting to not showing the option in the list for multi-select.
<img width="445" alt="Screen Shot 2022-04-15 at 6 47 03 PM" src="https://user-images.githubusercontent.com/12107173/163655369-f73297cc-0427-469f-b6f1-202829ba5fc3.png">
<img width="445" alt="Screen Shot 2022-04-15 at 6 46 48 PM" src="https://user-images.githubusercontent.com/12107173/163655375-ca68a19b-2e27-4740-a049-a8bb38dcb579.png">

