### PR TITLE
refactor: change named export to default

### DIFF
--- a/build-utils/build.ts
+++ b/build-utils/build.ts
@@ -99,6 +99,7 @@ const configs: ConfigOptions[] = [
       dir: 'dist',
       format: 'cjs',
       sourcemap: false,
+      exports: 'auto',
     },
     maxParallelFileReads: 200,
   },

--- a/src/stories/CountrySelect/CountryMultiSelect.stories.tsx
+++ b/src/stories/CountrySelect/CountryMultiSelect.stories.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 
 import { Meta, Story } from '@storybook/react/types-6-0';
-import {
-  CountryMultiSelect,
+import CountryMultiSelect, {
   CountryMultiSelectProps,
 } from 'src/components/select/CountryMultiSelect';
 import { withDesign } from 'storybook-addon-designs';

--- a/src/stories/CountrySelect/CountrySelect.stories.tsx
+++ b/src/stories/CountrySelect/CountrySelect.stories.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 
 import { Meta, Story } from '@storybook/react/types-6-0';
-import {
-  CountrySelect,
+import CountrySelect, {
   CountrySelectProps,
 } from 'src/components/select/CountrySelect';
 import { withDesign } from 'storybook-addon-designs';


### PR DESCRIPTION


## Description
<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
This PR allows rollup to be able to bundle both default export and named export
