### PR TITLE
Feat/add text button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.0.63",
+  "version": "3.0.64",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -109,31 +109,6 @@ const Secondary = styled(AminoButton)`
   }
 `;
 
-const Icon = styled(AminoButton)`
-  background: var(--amino-input-background);
-  color: var(--amino-text-color);
-  padding: 0 var(--amino-space-half);
-  border: var(--amino-border);
-  box-shadow: var(--amino-shadow-small);
-
-  svg {
-    fill: currentColor;
-    color: var(--amino-text-color);
-  }
-
-  &:hover {
-    background: var(--amino-gray-200);
-  }
-  &:active,
-  &:focus {
-    background: var(--amino-blue-100);
-    color: var(--amino-blue-500);
-  }
-  ${StyledSpinnerWrapper} {
-    background: var(--amino-input-background);
-  }
-`;
-
 const Danger = styled(AminoButton)`
   background: var(--amino-red-500);
   color: white;
@@ -205,14 +180,22 @@ const Subtle = styled(AminoButton)`
   &.loading {
     color: transparent;
   }
-  & > *:not(${StyledSpinnerWrapper}) {
-    opacity: 0;
+`;
+
+const TextButton = styled(AminoButton)<ButtonProps>`
+  height: 16px;
+  line-height: 14px;
+  padding: 0;
+
+  &.loading {
+    color: transparent;
   }
 `;
 
-type IntentProps = 'outline' | 'subtle' | Intent;
+type IntentProps = 'outline' | 'subtle' | 'text' | Intent;
 
 type ButtonType = {
+  as?: 'button' | 'a';
   children?: ReactNode;
   className?: string;
   disabled?: boolean;
@@ -232,6 +215,7 @@ export type ButtonProps = ButtonType &
   Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonType>;
 
 export const Button = ({
+  as = 'button',
   children,
   className,
   disabled,
@@ -275,6 +259,7 @@ export const Button = ({
     case 'primary':
       return (
         <Primary
+          as={as}
           className={buttonClassName}
           data-tip={tooltip}
           onClick={onClick}
@@ -291,6 +276,7 @@ export const Button = ({
     case 'subtle':
       return (
         <Subtle
+          as={as}
           className={buttonClassName}
           data-tip={tooltip}
           onClick={onClick}
@@ -307,6 +293,7 @@ export const Button = ({
     case 'outline':
       return (
         <Outline
+          as={as}
           className={buttonClassName}
           data-tip={tooltip}
           onClick={onClick}
@@ -323,6 +310,7 @@ export const Button = ({
     case 'warning':
       return (
         <Warning
+          as={as}
           className={buttonClassName}
           data-tip={tooltip}
           onClick={onClick}
@@ -339,6 +327,7 @@ export const Button = ({
     case 'danger':
       return (
         <Danger
+          as={as}
           className={buttonClassName}
           data-tip={tooltip}
           onClick={onClick}
@@ -352,9 +341,10 @@ export const Button = ({
           {loading && renderSpinner()}
         </Danger>
       );
-    case 'icon':
+    case 'text':
       return (
-        <Icon
+        <TextButton
+          as={as}
           className={buttonClassName}
           data-tip={tooltip}
           onClick={onClick}
@@ -366,12 +356,13 @@ export const Button = ({
         >
           {content}
           {loading && renderSpinner()}
-        </Icon>
+        </TextButton>
       );
     case 'secondary':
     default:
       return (
         <Secondary
+          as={as}
           className={buttonClassName}
           data-tip={tooltip}
           onClick={onClick}

--- a/src/stories/Button/Button.stories.tsx
+++ b/src/stories/Button/Button.stories.tsx
@@ -37,109 +37,41 @@ const ButtonMeta: Meta = {
   },
 };
 
-const StyledWrapper = styled.div`
+const HWrapper = styled.div`
   display: flex;
-  gap: 20px;
+  gap: 40px;
   flex-direction: row;
+`;
+const VWrapper = styled.div`
+  display: flex;
+  gap: 40px;
+  flex-direction: column;
 `;
 
 export default ButtonMeta;
 
-const Template: Story<ButtonProps> = ({
-  children,
-  className,
-  disabled,
-  intent,
-  loading,
-  loadingText,
-  onClick,
-  size,
-  tabIndex,
-  tooltip,
-}) => (
-  <StyledWrapper>
-    {intent === 'icon' ? (
-      <Button
-        className={className}
-        disabled={disabled}
-        intent={intent}
-        loading={loading}
-        loadingText={loadingText}
-        onClick={onClick}
-        size={size}
-        tabIndex={tabIndex}
-        tooltip={tooltip}
-      >
-        {children}
-      </Button>
-    ) : (
-      <>
-        <div>
-          <Button
-            className={className}
-            disabled={disabled}
-            intent={intent}
-            loading={loading}
-            loadingText={loadingText}
-            onClick={onClick}
-            size={size}
-            tabIndex={tabIndex}
-            tooltip={tooltip}
-          >
-            {children}
-          </Button>
-        </div>
-        <div>
-          <Button
-            className={className}
-            disabled={disabled}
-            intent={intent}
-            icon={<CubeIcon size={16} />}
-            loading={loading}
-            loadingText={loadingText}
-            onClick={onClick}
-            size={size}
-            tabIndex={tabIndex}
-            tooltip={tooltip}
-          >
-            {children}
-          </Button>
-        </div>
-        <div>
-          <Button
-            className={className}
-            disabled={disabled}
-            intent={intent}
-            icon={<CubeIcon size={16} />}
-            iconRight
-            loading={loading}
-            loadingText={loadingText}
-            onClick={onClick}
-            size={size}
-            tabIndex={tabIndex}
-            tooltip={tooltip}
-          >
-            {children}
-          </Button>
-        </div>
-        <div>
-          <Button
-            className={className}
-            disabled={disabled}
-            intent={intent}
-            icon={<CubeIcon size={16} />}
-            loading={loading}
-            loadingText={loadingText}
-            onClick={onClick}
-            size={size}
-            tabIndex={tabIndex}
-            tooltip={tooltip}
-          />
-        </div>
-      </>
-    )}
-  </StyledWrapper>
+const ButtonRow = ({ children, ...props }: ButtonProps) => (
+  <HWrapper>
+    <Button {...props}>{children}</Button>
+    <Button {...props} icon={<CubeIcon size={16} />}>
+      {children}
+    </Button>
+    <Button {...props} icon={<CubeIcon size={16} />} iconRight>
+      {children}
+    </Button>
+    <Button {...props} icon={<CubeIcon size={16} />} />
+  </HWrapper>
 );
+
+const Template: Story<ButtonProps> = props => {
+  return (
+    <VWrapper>
+      <ButtonRow {...props} />
+      <ButtonRow {...props} disabled />
+      <ButtonRow {...props} loading />
+    </VWrapper>
+  );
+};
 
 export const Default = Template.bind({});
 Default.args = {
@@ -189,18 +121,6 @@ Warning.parameters = {
   },
 };
 
-export const Subtle = Template.bind({});
-Subtle.args = {
-  intent: 'subtle',
-  children: 'Example button',
-};
-Subtle.parameters = {
-  design: {
-    type: 'figma',
-    url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A24',
-  },
-};
-
 export const Outline = Template.bind({});
 Outline.args = {
   intent: 'outline',
@@ -213,20 +133,20 @@ Outline.parameters = {
   },
 };
 
-export const Icon = Template.bind({});
-Icon.args = {
-  intent: 'icon',
-  children: (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 20 20"
-      fill="currentColor"
-    >
-      <path
-        fillRule="evenodd"
-        d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z"
-        clipRule="evenodd"
-      />
-    </svg>
-  ),
+export const Subtle = Template.bind({});
+Subtle.args = {
+  intent: 'subtle',
+  children: 'Example button',
+};
+Subtle.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A24',
+  },
+};
+
+export const TextButton = Template.bind({});
+TextButton.args = {
+  intent: 'text',
+  children: 'Back',
 };

--- a/src/types/Intent.ts
+++ b/src/types/Intent.ts
@@ -5,5 +5,4 @@ export type Intent =
   | 'info'
   | 'primary'
   | 'danger'
-  | 'secondary'
-  | 'icon';
+  | 'secondary';


### PR DESCRIPTION


## Description
<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
This PR adds a text button, removes the icon intent (no longer necessary), and fixes the subtle button.

### Text Button (Figma):
<img width="418" alt="Screen Shot 2022-06-16 at 12 13 40 PM" src="https://user-images.githubusercontent.com/12107173/174138346-281168e3-e1f8-491b-ace9-45981a306b46.png">

### Button stories
<img width="1033" alt="Screen Shot 2022-06-16 at 12 14 50 PM" src="https://user-images.githubusercontent.com/12107173/174138420-90f6ce20-6f1a-475f-94ac-38221cb1e645.png">

### Additional
There is an `as` Styled component prop which allows you to dynamically define the element to apply styles to.