### PR TITLE
Feat/tooltip subtitle react node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.0.69",
+  "version": "3.0.70",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -9,12 +9,8 @@ import { VStack } from 'src/components/stack/VStack';
 import { Text } from 'src/components/text/Text';
 import styled from 'styled-components';
 
-const StyledTitle = styled(Text)`
-  margin-top: 3px;
-`;
-
-const StyledCaption = styled(Text)`
-  margin-top: 3px;
+const StyledVStack = styled(VStack)`
+  padding-top: 3px;
 `;
 
 const NoTooltipWrapper = styled.div``;
@@ -42,7 +38,7 @@ export type TooltipProps = {
   children: ReactNode;
   className?: string;
   showTooltip: boolean;
-  subtitle: string | null;
+  subtitle: ReactNode | string | null;
   tag?: 'div' | 'span';
   title?: string;
 };
@@ -69,14 +65,18 @@ export const Tooltip = ({
       <StyledTooltip
         className={className}
         title={
-          <VStack spacing="space-quarter">
+          <StyledVStack spacing="space-quarter">
             {title && (
-              <StyledTitle type="small-header" isUppercase={false}>
+              <Text type="small-header" isUppercase={false}>
                 {title}
-              </StyledTitle>
+              </Text>
             )}
-            <StyledCaption type="caption">{subtitle}</StyledCaption>
-          </VStack>
+            {typeof subtitle === 'string' ? (
+              <Text type="caption">{subtitle}</Text>
+            ) : (
+              subtitle
+            )}
+          </StyledVStack>
         }
       >
         <ChildWrapper as={tag}>

--- a/src/stories/Tooltip.stories.tsx
+++ b/src/stories/Tooltip.stories.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { Button, ButtonProps } from 'src/components/button/Button';
+import { VStack } from 'src/components/stack/VStack';
+import { Text } from 'src/components/text/Text';
 import { Tooltip, TooltipProps } from 'src/components/tooltip/Tooltip';
 import { CubeIcon } from 'src/icons/CubeIcon';
 import { truncateText } from 'src/utils/truncateText';
@@ -76,11 +78,15 @@ const WithoutHeadingTooltip = ({
   <Tooltip
     {...props}
     showTooltip
-    subtitle={truncateText({
-      length: 128,
-      addEllipses: false,
-      text: subtitle,
-    })}
+    subtitle={
+      typeof subtitle === 'string'
+        ? truncateText({
+            length: 128,
+            addEllipses: false,
+            text: subtitle,
+          })
+        : subtitle
+    }
   >
     {children}
   </Tooltip>
@@ -106,6 +112,18 @@ const ButtonRow = (props: ButtonProps) => (
         Without heading
       </StyledButton>
     </WithoutHeadingTooltip>
+    <Tooltip
+      showTooltip
+      subtitle={
+        <VStack>
+          <Text>A</Text>
+          <Text>Custom</Text>
+          <Text>Subtitle</Text>
+        </VStack>
+      }
+    >
+      <StyledButton>Custom subtitle</StyledButton>
+    </Tooltip>
   </HWrapper>
 );
 


### PR DESCRIPTION


## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR changes the `Tooltip.subtitle` prop to include a React node. We have a few places in Dashboard where we have a custom `Tooltip.subtitle`.

## Todo

- [x] Bump version and add tag
