### PR TITLE
feat(toast):added intent/options to Toast

### DIFF
--- a/build-utils/css/constants/theme.ts
+++ b/build-utils/css/constants/theme.ts
@@ -423,6 +423,7 @@ export const theme = {
   /* FONTS */
   'font-sans': `'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif`,
   'font-mono': `Operator Mono, MonoLisa, Dank Mono, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace`,
+  'harmonized-codes': `'Fira Code', var(--amino-font-sans)`,
 } as const;
 
 export type ThemeKey = keyof typeof theme;

--- a/build-utils/css/utils/__snapshots__/theme.css
+++ b/build-utils/css/utils/__snapshots__/theme.css
@@ -281,4 +281,5 @@
   --amino-font-mono: Operator Mono, MonoLisa, Dank Mono, Menlo, Monaco,
     Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono,
     Courier New, monospace;
+  --amino-harmonized-codes: 'Fira Code', var(--amino-font-sans);
 }

--- a/build-utils/css/utils/__tests__/__snapshots__/convertToCssVariable.test.ts.snap
+++ b/build-utils/css/utils/__tests__/__snapshots__/convertToCssVariable.test.ts.snap
@@ -133,6 +133,7 @@ Object {
   "--amino-green-l40": "#66db66",
   "--amino-green-l60": "#99e799",
   "--amino-green-l80": "#e5f9e5",
+  "--amino-harmonized-codes": "'Fira Code', var(--amino-font-sans)",
   "--amino-header-color": "white",
   "--amino-hover-color": "var(--amino-gray-50)",
   "--amino-input-background": "white",

--- a/build-utils/css/utils/__tests__/__snapshots__/generateAminoConstants.test.ts.snap
+++ b/build-utils/css/utils/__tests__/__snapshots__/generateAminoConstants.test.ts.snap
@@ -865,6 +865,9 @@ exports[`Case light theme 1`] = `
   /** @info Operator Mono, MonoLisa, Dank Mono, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace */
   /* THIS IS GENERATED VARIABLE! DON'T TOUCH IT!!! */
   'font-mono': 'var(--amino-font-mono)',
+  /** @info 'Fira Code', var(--amino-font-sans) */
+  /* THIS IS GENERATED VARIABLE! DON'T TOUCH IT!!! */
+  'harmonized-codes': 'var(--amino-harmonized-codes)',
 } as const;
 
 export type ThemeKey = keyof typeof theme;

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -13,7 +13,7 @@ const AminoToast = styled(motion.div)`
   background: ${theme['gray-l80']};
   z-index: 999999;
   border-radius: var(--amino-radius-lg);
-  color: white;
+  color: ${theme['gray-d80']};
   box-shadow: var(--amino-shadow-medium);
   padding: var(--amino-space-half) var(--amino-space);
   display: flex;
@@ -47,7 +47,7 @@ const AminoInfoToast = styled(AminoToast)`
 
 export type ToastProps = {
   children: React.ReactNode;
-  intent?: Intent;
+  intent?: Extract<Intent, 'success' | 'warning' | 'error' | 'info'>;
   toastKey: string;
 };
 

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,15 +1,23 @@
 import React from 'react';
 
 import { motion } from 'framer-motion';
+import { CheckCircleDuotoneIcon } from 'src/icons/CheckCircleDuotoneIcon';
+import { InfoDuotoneIcon } from 'src/icons/InfoDuotoneIcon';
+import { RemoveCircleDuotoneIcon } from 'src/icons/RemoveCircleDuotoneIcon';
+import { WarningDuotoneIcon } from 'src/icons/WarningDuotoneIcon';
+import { theme } from 'src/styles/constants/theme';
+import { Intent } from 'src/types';
 import styled from 'styled-components';
 
 const AminoToast = styled(motion.div)`
-  background: var(--amino-gray-700);
+  background: ${theme['gray-l80']};
   z-index: 999999;
   border-radius: var(--amino-radius-lg);
   color: white;
   box-shadow: var(--amino-shadow-medium);
   padding: var(--amino-space-half) var(--amino-space);
+  display: flex;
+  gap: ${theme['space-quarter']};
   font-weight: 500;
   user-select: none;
 
@@ -18,18 +26,77 @@ const AminoToast = styled(motion.div)`
   }
 `;
 
-type Props = {
+const AminoSuccessToast = styled(AminoToast)`
+  background-color: ${theme['green-l80']};
+  color: ${theme['green-d40']};
+`;
+
+const AminoErrorToast = styled(AminoToast)`
+  background-color: ${theme['red-l80']};
+  color: ${theme['red-d40']};
+`;
+
+const AminoWarningToast = styled(AminoToast)`
+  background-color: ${theme['orange-l80']};
+  color: ${theme['orange-d40']};
+`;
+const AminoInfoToast = styled(AminoToast)`
+  background-color: ${theme['blue-l80']};
+  color: ${theme['blue-d40']};
+`;
+
+export type ToastProps = {
+  children: React.ReactNode;
+  intent?: Intent;
   toastKey: string;
 };
 
-export const Toast: React.FC<Props> = ({ children, toastKey }) => (
-  <AminoToast
-    layout
-    key={toastKey}
-    initial={{ opacity: 0, translateX: 10 }}
-    animate={{ opacity: 1, translateX: 0 }}
-    exit={{ opacity: 0 }}
-  >
-    {children}
-  </AminoToast>
-);
+export const Toast: React.FC<ToastProps> = ({ children, intent, toastKey }) => {
+  const baseProps = {
+    key: toastKey,
+    initial: { opacity: 0, translateX: 10 },
+    animate: { opacity: 1, translateX: 0 },
+    exit: { opacity: 0 },
+  };
+  switch (intent) {
+    case 'success':
+      return (
+        <AminoSuccessToast layout {...baseProps}>
+          <CheckCircleDuotoneIcon
+            color="green-d60"
+            secondaryColor="green-l40"
+          />
+          {children}
+        </AminoSuccessToast>
+      );
+    case 'error':
+      return (
+        <AminoErrorToast layout {...baseProps}>
+          <RemoveCircleDuotoneIcon color="red-d60" secondaryColor="red-l40" />
+          {children}
+        </AminoErrorToast>
+      );
+    case 'warning':
+      return (
+        <AminoWarningToast layout {...baseProps}>
+          <WarningDuotoneIcon color="orange-d60" secondaryColor="orange-l40" />
+          {children}
+        </AminoWarningToast>
+      );
+
+    case 'info':
+      return (
+        <AminoInfoToast layout {...baseProps}>
+          <InfoDuotoneIcon color="blue-d60" secondaryColor="blue-l40" />
+          {children}
+        </AminoInfoToast>
+      );
+    default:
+      return (
+        <AminoToast layout {...baseProps}>
+          <InfoDuotoneIcon color="gray-d60" secondaryColor="gray-l40" />
+          {children}
+        </AminoToast>
+      );
+  }
+};

--- a/src/components/toast/ToastContext.tsx
+++ b/src/components/toast/ToastContext.tsx
@@ -8,18 +8,14 @@ import React, {
 
 import { AnimatePresence } from 'framer-motion';
 
-import { Toast } from './Toast';
+import { Toast, ToastProps } from './Toast';
 
 export const ToastContext = createContext((toast: ReactNode): void => {
   const defaultFunction = (options: ReactNode) => options;
   defaultFunction(toast);
 });
 
-type Props = {
-  children: ReactNode;
-};
-
-export const ToastContextProvider = ({ children }: Props) => {
+export const ToastContextProvider = ({ children, intent }: ToastProps) => {
   const [toasts, setToasts] = useState<ReactNode[]>([]);
 
   useEffect(() => {
@@ -42,14 +38,20 @@ export const ToastContextProvider = ({ children }: Props) => {
     <AnimatePresence>
       <ToastContext.Provider value={addToast}>
         {children}
-        <div className="toasts-wrapper">
-          <AnimatePresence>
-            {toasts.map(toast => (
-              <Toast toastKey={`toast-${toast}`} key={`toast-${toast}`}>
-                {toast}
-              </Toast>
-            ))}
-          </AnimatePresence>
+        <div className="toast-container">
+          <div className="toasts-wrapper">
+            <AnimatePresence>
+              {toasts.map(toast => (
+                <Toast
+                  toastKey={`toast-${toast}`}
+                  key={`toast-${toast}`}
+                  intent={intent}
+                >
+                  {toast}
+                </Toast>
+              ))}
+            </AnimatePresence>
+          </div>
         </div>
       </ToastContext.Provider>
     </AnimatePresence>

--- a/src/stories/Toast/Toast.stories.tsx
+++ b/src/stories/Toast/Toast.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Meta, Story } from '@storybook/react/types-6-0';
+import { ToastProps } from 'src/components/toast/Toast';
 import { ToastContextProvider } from 'src/components/toast/ToastContext';
 import { withDesign } from 'storybook-addon-designs';
 
@@ -14,8 +15,13 @@ const ToastContextProviderMeta: Meta = {
 
 export default ToastContextProviderMeta;
 
-const Template: Story = () => (
-  <ToastContextProvider>
+const Template: Story<ToastProps> = ({
+  intent,
+  children,
+  toastKey,
+}: ToastProps) => (
+  <ToastContextProvider intent={intent} toastKey={toastKey}>
+    {children}
     <ToastConsumer />
   </ToastContextProvider>
 );

--- a/src/stories/Toast/Toast.stories.tsx
+++ b/src/stories/Toast/Toast.stories.tsx
@@ -15,12 +15,8 @@ const ToastContextProviderMeta: Meta = {
 
 export default ToastContextProviderMeta;
 
-const Template: Story<ToastProps> = ({
-  intent,
-  children,
-  toastKey,
-}: ToastProps) => (
-  <ToastContextProvider intent={intent} toastKey={toastKey}>
+const Template: Story<ToastProps> = ({ children }: ToastProps) => (
+  <ToastContextProvider>
     {children}
     <ToastConsumer />
   </ToastContextProvider>

--- a/src/stories/Toast/ToastConsumer.tsx
+++ b/src/stories/Toast/ToastConsumer.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 
 import { Button } from 'src/components/button/Button';
+import { VStack } from 'src/components/stack/VStack';
 import { ToastContext } from 'src/components/toast/ToastContext';
 
 const useNotify = () => {
@@ -11,8 +12,20 @@ export const ToastConsumer = () => {
   const notify = useNotify();
 
   return (
-    <div>
-      <Button onClick={() => notify('This is a notification.')}>Notify</Button>
-    </div>
+    <VStack>
+      <Button onClick={() => notify('Default toast')}>Notify</Button>
+      <Button onClick={() => notify('Success toast', { intent: 'success' })}>
+        Success
+      </Button>
+      <Button onClick={() => notify('Error toast', { intent: 'error' })}>
+        Error
+      </Button>
+      <Button onClick={() => notify('Warning toast', { intent: 'warning' })}>
+        Warning
+      </Button>
+      <Button onClick={() => notify('Info toast', { intent: 'info' })}>
+        Information
+      </Button>
+    </VStack>
   );
 };

--- a/src/styles/amino.css
+++ b/src/styles/amino.css
@@ -108,9 +108,12 @@ h6 {
   overflow: hidden;
 }
 
+.toast-container {
+  display: flex;
+  justify-content: center;
+}
 .toasts-wrapper {
   position: fixed;
   z-index: 9999999;
   bottom: var(--amino-space-double);
-  right: var(--amino-space-double);
 }

--- a/src/styles/constants/theme.ts
+++ b/src/styles/constants/theme.ts
@@ -862,6 +862,9 @@ export const theme = {
   /** @info Operator Mono, MonoLisa, Dank Mono, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace */
   /* THIS IS GENERATED VARIABLE! DON'T TOUCH IT!!! */
   'font-mono': 'var(--amino-font-mono)',
+  /** @info 'Fira Code', var(--amino-font-sans) */
+  /* THIS IS GENERATED VARIABLE! DON'T TOUCH IT!!! */
+  'harmonized-codes': 'var(--amino-harmonized-codes)',
 } as const;
 
 export type ThemeKey = keyof typeof theme;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -281,6 +281,7 @@
   --amino-font-mono: Operator Mono, MonoLisa, Dank Mono, Menlo, Monaco,
     Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono,
     Courier New, monospace;
+  --amino-harmonized-codes: 'Fira Code', var(--amino-font-sans);
 }
 
 /* Dark theme */


### PR DESCRIPTION
## Jira issue
[FE: Add category and subcategory selection (final step) to Classify Interactive in dashboard UI](https://myzonos.atlassian.net/jira/software/projects/CLSFY/boards/65?assignee=603058259f84a900690cdd2b&selectedIssue=CLSFY-1512)

## Description
This PR adds the Figma design for Toast notifications and added intent for different options. 'Success' toast needed for Classify figma design. 

## Todo

- [ ] Bump version and add tag
