### PR TITLE
feat: make helptext and error be more sensible types and update stories.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/help-text/HelpText.tsx
+++ b/src/components/help-text/HelpText.tsx
@@ -9,31 +9,36 @@ const StyledHelpText = styled.div`
 `;
 
 export type HelpTextProps = {
-  error?: ReactNode;
+  /**
+   * Is this an error state.
+   */
+  error?: boolean;
+  /**
+   * Shows below input. Use in conjunction with `error` to show feedback about error.
+   */
   helpText?: ReactNode;
 };
 
 export const HelpText = ({ error, helpText }: HelpTextProps) => {
-  if (helpText && error && typeof error === 'string') {
-    return (
-      <StyledHelpText>
-        <Text type="caption" color="red-d20">
-          {error}
-        </Text>
-      </StyledHelpText>
-    );
-  }
-  if (helpText && error) {
-    return <StyledHelpText>{error}</StyledHelpText>;
-  }
-  if (helpText && typeof helpText === 'string') {
-    return (
-      <StyledHelpText>
-        <Text type="caption">{helpText}</Text>
-      </StyledHelpText>
-    );
-  }
   if (helpText) {
+    if (error && typeof helpText === 'string') {
+      return (
+        <StyledHelpText>
+          <Text type="caption" color="red-d20">
+            {helpText}
+          </Text>
+        </StyledHelpText>
+      );
+    }
+
+    if (typeof helpText === 'string') {
+      return (
+        <StyledHelpText>
+          <Text type="caption">{helpText}</Text>
+        </StyledHelpText>
+      );
+    }
+
     return <StyledHelpText>{helpText}</StyledHelpText>;
   }
   return null;

--- a/src/components/input/input-type/_FloatLabelInput.tsx
+++ b/src/components/input/input-type/_FloatLabelInput.tsx
@@ -6,6 +6,7 @@ import React, {
   useMemo,
 } from 'react';
 
+import { HelpTextProps } from 'src/components/help-text/HelpText';
 import { theme } from 'src/styles/constants/theme';
 import { Size } from 'src/types/Size';
 import { getTestId } from 'src/utils/getTestId';
@@ -221,9 +222,6 @@ type FloatLabelInputType = {
   /** Determines input type (email, password, etc.) */
   type?: HTMLInputTypeAttribute;
 
-  /** If present, will display an error message instead of help text */
-  error?: string;
-
   /** A short string displayed at the beginning of the input */
   prefix?: ReactNode;
 
@@ -241,7 +239,7 @@ type FloatLabelInputType = {
   autoFocus?: boolean;
   size?: Size;
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
-};
+} & Pick<HelpTextProps, 'error'>;
 export type FloatLabelInputProps = FloatLabelInputType &
   Omit<InputHTMLAttributes<HTMLInputElement>, keyof FloatLabelInputType>;
 
@@ -287,7 +285,7 @@ export const FloatLabelInput = forwardRef<
         <AminoInput
           aria-label={label}
           className={[
-            error && error.length ? 'has-error' : '',
+            error ? 'has-error' : '',
             label ? 'has-label' : '',
             hasValue ? 'has-content' : '',
             prefix ? 'has-input-prefix' : '',

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -176,11 +176,17 @@ InputWithHelpText.args = {
   helpText: "This is the input's help text",
 };
 
-export const InputWithErrorText = Template.bind({});
-InputWithErrorText.args = {
+export const InputWithError = Template.bind({});
+InputWithError.args = {
   label: 'Example input',
-  error: 'This is an error',
-  helpText: "This is the input's help text",
+  error: true,
+};
+
+export const InputWithErrorAndHelpText = Template.bind({});
+InputWithErrorAndHelpText.args = {
+  label: 'Example input',
+  error: true,
+  helpText: 'This is an error',
 };
 
 export const Prefix = Template.bind({});
@@ -220,4 +226,26 @@ Suffix.parameters = {
     type: 'figma',
     url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A63',
   },
+};
+
+export const DynamicErrorAndHelpText: Story<InputProps> = ({
+  value: _value,
+  ...props
+}) => {
+  const [value, setValue] = useState(_value);
+  const hasError = value?.length === 0;
+  return (
+    <VStack>
+      <Input
+        {...props}
+        error={hasError}
+        helpText={hasError ? 'This field is required' : 'Enter some stuff'}
+        onChange={e => setValue(e.target.value)}
+        value={value}
+      />
+      <Text type="bold-subheader">
+        Value: <Text type="code">{value || '--'}</Text>
+      </Text>
+    </VStack>
+  );
 };

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -84,8 +84,8 @@ BasicSelect.parameters = {
 export const BasicSelectWithIcon = SelectTemplate.bind({});
 
 BasicSelectWithIcon.args = {
-  error: 'This input is required',
-  helpText: 'Your currency',
+  error: true,
+  helpText: 'This input is required',
   icon: <FileIcon size={20} />,
   label: 'Currencies',
   value: {


### PR DESCRIPTION
## Description

The `error` and `helpText` props for Inputs were very confusing in their functionality.
I changed it to make `error` a boolean for an error state, and `helperText` be whatever text is shown below, error or otherwise. See the new input story for a demo.

Upstream users will have invalid `error` prop types, but most of those can probably be fixed by making the previous error value evaluate the falsiness, as most cases look like this:
```tsx
<Input
  helpText={renderIossHelpText()}
  error={renderIossHelpText()}
  label="IOSS VAT number"
  onChange={({ target: { value } }) => setIossNumber(value)}
  value={iossNumber || ''}
/>
```

## Todo

- [ ] Bump version and add tag
