### PR TITLE
fix: native datetime placeholder is hidden correctly now

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.2.14",
+  "version": "3.2.15",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/input/input-type/_DateInput.tsx
+++ b/src/components/input/input-type/_DateInput.tsx
@@ -46,7 +46,7 @@ const AminoInput = styled(FloatLabelInput)`
     }
     &:not(:focus):not(.has-content) {
       &::-webkit-datetime-edit-fields-wrapper {
-        color: transparent;
+        opacity: 0;
       }
     }
   }

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -152,10 +152,28 @@ DateInput.parameters = {
   },
 };
 
+export const DateInputClamped = Template.bind({});
+DateInputClamped.args = {
+  label: 'Date input with range',
+  placeholder: 'placeholder',
+  type: 'date',
+  min: new Date('2009-01-10').toISOString().split('T')[0],
+  max: new Date('2009-01-18').toISOString().split('T')[0],
+};
+
 export const DateTimeInput = Template.bind({});
 DateTimeInput.args = {
   label: 'Datetime input',
   type: 'datetime-local',
+};
+
+export const DateTimeInputClamped = Template.bind({});
+DateTimeInputClamped.args = {
+  label: 'Datetime input with range',
+  placeholder: 'placeholder',
+  type: 'datetime-local',
+  min: new Date('2009-01-10T03:24:00').toISOString().slice(0, -1),
+  max: new Date('2009-01-18T03:50:00').toISOString().slice(0, -1),
 };
 
 export const TimeInput = Template.bind({});


### PR DESCRIPTION
## Description

Given a `min` and `max` for a date input, it will render a native placeholder, which interfered with our label. This fixes that (thanks @Thienhuynh95 for the fix)

Old:
![image](https://user-images.githubusercontent.com/50718218/189432367-603bb651-ad89-4138-9163-3be1bb3f2d3f.png)

The new one just hides that placeholder until we focus.
<img width="794" alt="image" src="https://user-images.githubusercontent.com/50718218/189432524-996cc7a7-6a5b-48bf-b33b-ab8586d5806b.png">


## Todo

- [ ] Bump version and add tag
