### PR TITLE
FIX: Allow div props on vstack

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "text-treeview": "^1.0.2",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.7.0",
+    "ts-toolbelt": "^9.6.0",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "tslib": "^2.4.0",
     "ttypescript": "^1.5.13",

--- a/src/components/stack/Stack.tsx
+++ b/src/components/stack/Stack.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import styled from 'styled-components';
-import { Any } from 'ts-toolbelt';
 
 import { GridAlignment, GridSpacing } from './GridSpacing';
 

--- a/src/components/stack/Stack.tsx
+++ b/src/components/stack/Stack.tsx
@@ -1,17 +1,25 @@
 import React from 'react';
 
 import styled from 'styled-components';
+import { Any } from 'ts-toolbelt';
 
 import { GridAlignment, GridSpacing } from './GridSpacing';
 
-export type StackProps = {
+type DivProps = Omit<
+  Partial<HTMLDivElement>,
+  | 'translate'
+  | 'style'
+  | 'prefix'
+  | 'contentEditable'
+  | 'inputMode'
+  | 'children'
+>;
+
+export interface StackProps extends DivProps {
   alignment?: GridAlignment;
   spacing?: GridSpacing;
   children: React.ReactNode;
-} & Omit<
-  HTMLDivElement,
-  'translate' | 'style' | 'prefix' | 'contentEditable' | 'inputMode'
->;
+}
 /**
  * A stack
  *

--- a/src/components/stack/Stack.tsx
+++ b/src/components/stack/Stack.tsx
@@ -8,9 +8,10 @@ export type StackProps = {
   alignment?: GridAlignment;
   spacing?: GridSpacing;
   children: React.ReactNode;
-  className?: string;
-};
-
+} & Omit<
+  HTMLDivElement,
+  'translate' | 'style' | 'prefix' | 'contentEditable' | 'inputMode'
+>;
 /**
  * A stack
  *
@@ -20,21 +21,10 @@ export type StackProps = {
 const StyledStack = styled.div<StackProps>`
   display: grid;
   grid-auto-columns: minmax(0, 1fr);
-
   & > * {
     justify-self: ${p => p.alignment || 'unset'};
   }
 `;
-
-export const Stack = ({
-  className,
-  spacing,
-  alignment,
-  children,
-}: StackProps) => {
-  return (
-    <StyledStack className={className} spacing={spacing} alignment={alignment}>
-      {children}
-    </StyledStack>
-  );
+export const Stack = ({ children, ...otherProps }: StackProps) => {
+  return <StyledStack {...otherProps}>{children}</StyledStack>;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "strict": true,
+    "strictNullChecks": true,
     "target": "es5",
     "typeRoots": [
       "node_modules/@types",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13967,6 +13967,11 @@ ts-pnp@^1.1.6:
   resolved "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+ts-toolbelt@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
+  integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
+
 tsconfig-paths-webpack-plugin@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz#01aafff59130c04a8c4ebc96a3045c43c376449a"


### PR DESCRIPTION
## Description
There was an issue when I updated the docs to use the latest version of Amino. The Vstack typescript no longer allowed a tabIndex prop. This PR adds typing to allow that to happen. 