### PR TITLE
fix: TextAvatar inline styling

### DIFF
--- a/src/components/text-avatar/TextAvatar.tsx
+++ b/src/components/text-avatar/TextAvatar.tsx
@@ -1,14 +1,25 @@
 import React from 'react';
 
 import { theme } from 'src/styles/constants/theme';
-import styled from 'styled-components';
+import styled, { CSSProperties } from 'styled-components';
 
-type GraidentSquareType = {
+type GradientSquareType = {
   gradientStart: string;
   gradientEnd: string;
 };
 
-const GradientSquare = styled.div<GraidentSquareType>`
+// Used in store list, and when too many classes are generated styled-components complains. This is their recommended solution to make the changes styles inline, rather than generating a CSS class for each one.
+const GradientSquare = styled.div.attrs<GradientSquareType>(
+  (props): { style: CSSProperties } => ({
+    style: {
+      background: `linear-gradient(
+      137deg,
+      ${props.gradientStart},
+      ${props.gradientEnd}
+    )`,
+    },
+  })
+)<GradientSquareType>`
   width: 32px;
   height: 32px;
   border-radius: ${theme.radius};
@@ -18,15 +29,6 @@ const GradientSquare = styled.div<GraidentSquareType>`
   font-weight: 500;
   color: ${theme.grayD80} !important;
   font-weight: 500;
-
-  --gradient-start: ${p => p.gradientStart};
-  --gradient-end: ${p => p.gradientEnd};
-
-  background: linear-gradient(
-    137deg,
-    var(--gradient-start),
-    var(--gradient-end)
-  );
 `;
 
 export type TextAvatarProps = {

--- a/src/stories/TextAvatar.stories.tsx
+++ b/src/stories/TextAvatar.stories.tsx
@@ -2,22 +2,38 @@ import React from 'react';
 
 import { Meta, Story } from '@storybook/react/types-6-0';
 import {
-  TextAvatar,
+  TextAvatar as TextAvatarComponent,
   TextAvatarProps,
 } from 'src/components/text-avatar/TextAvatar';
+import { theme } from 'src/styles/constants/theme';
+import styled from 'styled-components';
 
 const TextAvatarMeta: Meta = {
   title: 'Amino/TextAvatar',
-  component: TextAvatar,
+  component: TextAvatarComponent,
 };
 
 export default TextAvatarMeta;
 
-const Template: Story<TextAvatarProps> = ({ label }: TextAvatarProps) => (
-  <TextAvatar label={label} />
+const Wrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${theme.space16};
+`;
+
+// Just a crazy function to make unique strings
+const codes = [...Array(250).keys()].map(
+  n =>
+    String.fromCharCode((n % 26) + 65).repeat(n % 40) +
+    String.fromCharCode(((n + 10) % 26) + 65)
 );
 
-export const BasicTextAvatar = Template.bind({});
-BasicTextAvatar.args = {
-  label: 'Rocketship Inc',
-};
+const Template: Story<TextAvatarProps> = () => (
+  <Wrapper>
+    {codes.map(n => (
+      <TextAvatarComponent label={n} key={n} />
+    ))}
+  </Wrapper>
+);
+
+export const TextAvatar = Template.bind({});


### PR DESCRIPTION
## Description

When trying to fix the store switcher in dashboard I ran into a serious scrolling performance issue. To make a (really) long story short, the issue was actually the styled component `TextAvatar` it was rendering. styled-components gave me a warning in the console for generating over 200 classes and a slightly cryptic fix.

TLDR: CSS class generation is computationally expensive, especially in large lists. Inline styles are quick. 

Also made the TextAvatar story more ... colorful 😄 

Console warning in question:
```
instrument.js?b344:107 Over 200 classes were generated for component styled.div with the id of "sc-jGprRt".
Consider using the attrs method, together with a style object for frequently changed styles.
Example:
  const Component = styled.div.attrs(props => ({
    style: {
      background: props.background,
    },
  }))`width: 100%;`

  <Component />
```

## Todo

- [ ] Bump version and add tag
