### PR TITLE
fix: revert d3-geo to pre type:module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.2.20",
+  "version": "3.2.21",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@mui/material": "^5.8.5",
     "@radix-ui/react-slider": "^0.1.4",
     "@types/topojson-client": "^3.1.1",
-    "d3-geo": "^3.0.1",
+    "d3-geo": "^2.0.2",
     "react-dropzone": "^12.0.4",
     "react-select": "^5.2.2",
     "react-simple-maps": "^3.0.0",
@@ -107,9 +107,6 @@
     "react-is": "^17.x",
     "react-tooltip": "^4.x",
     "styled-components": "^5.x"
-  },
-  "eslintConfig": {
-    "extends": "react-app"
   },
   "scripts": {
     "dev": "concurrently 'yarn storybook' 'yarn proxy'",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6619,13 +6619,6 @@ cyclist@^1.0.1:
   resolved "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-"d3-array@2.5.0 - 3":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.0.tgz#15bf96cd9b7333e02eb8de8053d78962eafcff14"
-  integrity sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==
-  dependencies:
-    internmap "1 - 2"
-
 d3-array@^2.5.0:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
@@ -6662,13 +6655,6 @@ d3-geo@^2.0.2:
   integrity sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==
   dependencies:
     d3-array "^2.5.0"
-
-d3-geo@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.0.1.tgz#4f92362fd8685d93e3b1fae0fd97dc8980b1ed7e"
-  integrity sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==
-  dependencies:
-    d3-array "2.5.0 - 3"
 
 "d3-interpolate@1 - 2":
   version "2.0.1"
@@ -8850,11 +8836,6 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
-
-"internmap@1 - 2":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
-  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 internmap@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION


## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes a Nextjs build error by reverting the `d3-geo` package down to 2.0.2 which is before `d3-geo` started compiling down to using the `import` syntax instead of the `require` syntax.

### Nextjs Build error:
```
require() of /vercel/path0/node_modules/d3-geo/src/index.js from /vercel/path0/node_modules/@amino-ui/core/components/connection-map/ConnectionMap.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
```


## Todo

- [x] Bump version and add tag
