### PR TITLE
feat: add esc and click out of dialog actions to close.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.2.22",
+  "version": "3.2.23",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/alert-dialog/AlertDialog.tsx
+++ b/src/components/alert-dialog/AlertDialog.tsx
@@ -75,7 +75,12 @@ export const AlertDialog = ({
   dismissText,
   dismissAction,
 }: AlertDialogProps) => (
-  <BaseDialog width={350} data-theme={_theme} open={open}>
+  <BaseDialog
+    width={350}
+    data-theme={_theme}
+    open={open}
+    onClose={dismissAction}
+  >
     <Content>
       <VStack spacing="space-half">
         <RoundedIcon intent={intent}>{getIconForIntent(intent)}</RoundedIcon>

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -7,6 +7,7 @@ import { theme } from 'src/styles/constants/theme';
 import { IAminoTheme } from 'src/types/IAminoTheme';
 import styled, { css } from 'styled-components';
 
+import { Button } from '../button/Button';
 import { BaseDialog } from './_BaseDialog';
 
 const Header = styled.div`
@@ -16,10 +17,35 @@ const Header = styled.div`
   display: flex;
   align-items: center;
 
-  h5 {
+  > :not(button) {
     margin: 0;
     flex: 1;
     font-weight: 700;
+  }
+`;
+
+const StyledButton = styled(Button)`
+  padding: 0;
+  path[data-is-secondary-color] {
+    fill: ${theme.grayL60};
+  }
+  &,
+  &:focus,
+  &:hover,
+  &:active {
+    color: ${theme.grayD60};
+    background: transparent;
+  }
+  &:hover {
+    path[data-is-secondary-color] {
+      fill: ${theme.grayL40};
+    }
+  }
+  &:active,
+  &:focus {
+    path[data-is-secondary-color] {
+      fill: ${theme.grayL20};
+    }
   }
 `;
 
@@ -104,28 +130,6 @@ const Content = styled.div`
   // gradientOverflow
 `;
 
-const Close = styled.div`
-  transition: all 100ms ease-in-out;
-  background: transparent;
-  border-radius: 32px;
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-
-  &:hover {
-    svg {
-      fill: ${theme.grayL20};
-    }
-  }
-
-  svg {
-    transition: all 100ms ease-in-out;
-  }
-`;
-
 export type DialogProps = {
   actions?: React.ReactNode;
   className?: string;
@@ -136,6 +140,14 @@ export type DialogProps = {
   open: boolean;
   theme?: IAminoTheme;
   width?: number;
+  /** Close when clicking outside dialog (on the backdrop)
+   * @default true
+   */
+  closeOnBlur?: boolean;
+  /** Close on pressing 'escape' key
+   * @default true
+   */
+  closeOnEsc?: boolean;
 };
 
 export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
@@ -150,6 +162,8 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
       open,
       theme: _theme,
       width,
+      closeOnBlur,
+      closeOnEsc,
     },
     ref
   ) => (
@@ -158,12 +172,16 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
       data-theme={_theme}
       open={open}
       width={width}
+      onClose={onClose}
+      closeOnBlur={closeOnBlur}
+      closeOnEsc={closeOnEsc}
     >
       <Header>
-        <Text type="subheader">{label}</Text>
-        <Close onClick={onClose}>
-          <RemoveCircleDuotoneIcon size={32} />
-        </Close>
+        <Text type="title">{label}</Text>
+        <StyledButton
+          onClick={onClose}
+          icon={<RemoveCircleDuotoneIcon size={32} />}
+        />
       </Header>
       <Content ref={ref}>{children}</Content>
       {(actions || leftActions) && (

--- a/src/components/dialog/_BaseDialog.tsx
+++ b/src/components/dialog/_BaseDialog.tsx
@@ -64,7 +64,9 @@ export const BaseDialog = ({
 
   // Focus the backdrop so we can listen for keypresses ('escape' to close)
   useEffect(() => {
-    dialogBackdrop?.current?.focus();
+    if (!dialogBackdrop.current?.contains(document.activeElement)) {
+      dialogBackdrop.current?.focus();
+    }
   }, [open]);
 
   if (typeof document !== 'undefined') {

--- a/src/components/dialog/_BaseDialog.tsx
+++ b/src/components/dialog/_BaseDialog.tsx
@@ -8,7 +8,6 @@ import { IAminoTheme } from 'src/types/IAminoTheme';
 import styled from 'styled-components';
 
 // TODO: scrollable dialog, max height, etc.
-// TODO: close with keyboard shortcut?
 
 const DialogLayout = styled.div`
   width: 100vw;

--- a/src/components/dialog/_BaseDialog.tsx
+++ b/src/components/dialog/_BaseDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 
 import { AnimatePresence, motion } from 'framer-motion';
@@ -34,12 +34,15 @@ const Popup = styled(motion.div)<{ width: number }>`
   border: ${theme.border};
 `;
 
-export type DialogProps = {
+export type BaseDialogProps = {
   children: React.ReactNode;
   className?: string;
   open: boolean;
   theme?: IAminoTheme;
   width?: number;
+  onClose: () => void;
+  closeOnBlur?: boolean;
+  closeOnEsc?: boolean;
 };
 
 export const BaseDialog = ({
@@ -48,7 +51,22 @@ export const BaseDialog = ({
   open,
   theme: _theme,
   width,
-}: DialogProps) => {
+  onClose,
+  closeOnBlur = true,
+  closeOnEsc = true,
+}: BaseDialogProps) => {
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (closeOnEsc && event.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  const dialogBackdrop = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    dialogBackdrop?.current?.focus();
+  }, [open]);
+
   if (typeof document !== 'undefined') {
     return ReactDOM.createPortal(
       <AnimatePresence>
@@ -63,7 +81,13 @@ export const BaseDialog = ({
           />
         )}
         {open && (
-          <DialogLayout data-theme={_theme}>
+          <DialogLayout
+            data-theme={_theme}
+            onClick={() => closeOnBlur && onClose()}
+            onKeyDown={handleKeyDown}
+            tabIndex={-1}
+            ref={dialogBackdrop}
+          >
             <Popup
               className={className}
               transition={{ ease: [0.4, 0, 0.2, 1], duration: 0.3 }}
@@ -72,6 +96,10 @@ export const BaseDialog = ({
               exit={{ opacity: 0, scale: 0.95 }}
               key="dialog"
               width={width || 444}
+              onClick={e => {
+                // e.preventDefault();
+                e.stopPropagation();
+              }}
             >
               {children}
             </Popup>

--- a/src/components/dialog/_BaseDialog.tsx
+++ b/src/components/dialog/_BaseDialog.tsx
@@ -40,7 +40,7 @@ export type BaseDialogProps = {
   open: boolean;
   theme?: IAminoTheme;
   width?: number;
-  onClose: () => void;
+  onClose?: () => void;
   closeOnBlur?: boolean;
   closeOnEsc?: boolean;
 };
@@ -56,13 +56,14 @@ export const BaseDialog = ({
   closeOnEsc = true,
 }: BaseDialogProps) => {
   const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (closeOnEsc && event.key === 'Escape') {
+    if (onClose && closeOnEsc && event.key === 'Escape') {
       onClose();
     }
   };
 
   const dialogBackdrop = useRef<HTMLDivElement>(null);
 
+  // Focus the backdrop so we can listen for keypresses ('escape' to close)
   useEffect(() => {
     dialogBackdrop?.current?.focus();
   }, [open]);
@@ -83,7 +84,7 @@ export const BaseDialog = ({
         {open && (
           <DialogLayout
             data-theme={_theme}
-            onClick={() => closeOnBlur && onClose()}
+            onClick={() => onClose && closeOnBlur && onClose()}
             onKeyDown={handleKeyDown}
             tabIndex={-1}
             ref={dialogBackdrop}
@@ -97,7 +98,7 @@ export const BaseDialog = ({
               key="dialog"
               width={width || 444}
               onClick={e => {
-                // e.preventDefault();
+                e.preventDefault();
                 e.stopPropagation();
               }}
             >

--- a/src/stories/Dialog.stories.tsx
+++ b/src/stories/Dialog.stories.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { Button } from 'src/components/button/Button';
 import { Dialog, DialogProps } from 'src/components/dialog/Dialog';
+import { Input } from 'src/components/input/Input';
 import { withDesign } from 'storybook-addon-designs';
 import styled from 'styled-components';
 
@@ -10,6 +11,12 @@ const DialogMeta: Meta = {
   title: 'Amino/Dialog',
   component: Dialog,
   decorators: [withDesign],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/WnKnmG7L3Q74hqPsw4rbEE/Amino-2.0?node-id=224%3A16329',
+    },
+  },
 };
 
 export default DialogMeta;
@@ -58,12 +65,6 @@ BasicDialog.args = {
   label: 'Dialog title',
   width: 460,
 };
-BasicDialog.parameters = {
-  design: {
-    type: 'figma',
-    url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=102%3A79',
-  },
-};
 
 export const WithLeftActions = Template.bind({});
 WithLeftActions.args = {
@@ -81,12 +82,6 @@ WithLeftActions.args = {
   children: <div>Children</div>,
   label: 'Dialog title',
   width: 650,
-};
-WithLeftActions.parameters = {
-  design: {
-    type: 'figma',
-    url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=102%3A79',
-  },
 };
 
 export const LongContentDialog = Template.bind({});
@@ -138,9 +133,34 @@ LongContentDialog.args = {
   label: 'Label',
   width: 500,
 };
-LongContentDialog.parameters = {
-  design: {
-    type: 'figma',
-    url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=102%3A79',
-  },
+
+export const WithInput = () => {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState('');
+
+  return (
+    <CenteredDiv>
+      <Button onClick={() => setOpen(true)}>Open</Button>
+      <Dialog
+        actions={
+          <>
+            <Button intent="outline" onClick={() => setOpen(false)}>
+              Close
+            </Button>
+            <Button intent="primary">Submit</Button>
+          </>
+        }
+        label="With an input"
+        open={open}
+        onClose={() => setOpen(false)}
+        width={460}
+      >
+        <Input
+          onChange={e => setValue(e.target.value)}
+          value={value}
+          autoFocus
+        />
+      </Dialog>
+    </CenteredDiv>
+  );
 };

--- a/src/stories/Dialog.stories.tsx
+++ b/src/stories/Dialog.stories.tsx
@@ -48,6 +48,25 @@ const Template: Story<DialogProps> = ({
 
 export const BasicDialog = Template.bind({});
 BasicDialog.args = {
+  actions: (
+    <>
+      <Button intent="outline">Close</Button>
+      <Button intent="primary">Save</Button>
+    </>
+  ),
+  children: <div>Children</div>,
+  label: 'Dialog title',
+  width: 460,
+};
+BasicDialog.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=102%3A79',
+  },
+};
+
+export const WithLeftActions = Template.bind({});
+WithLeftActions.args = {
   leftActions: (
     <>
       <Button>Back</Button>
@@ -55,15 +74,15 @@ BasicDialog.args = {
   ),
   actions: (
     <>
-      <Button>Close</Button>
+      <Button intent="outline">Close</Button>
       <Button intent="primary">Save</Button>
     </>
   ),
   children: <div>Children</div>,
-  label: 'Label',
+  label: 'Dialog title',
   width: 650,
 };
-BasicDialog.parameters = {
+WithLeftActions.parameters = {
   design: {
     type: 'figma',
     url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=102%3A79',
@@ -79,7 +98,7 @@ LongContentDialog.args = {
   ),
   actions: (
     <>
-      <Button>Close</Button>
+      <Button intent="outline">Close</Button>
       <Button intent="primary">Save</Button>
     </>
   ),


### PR DESCRIPTION
## Description

Adds pressing `escape` or clicking outside of dialog for options to close it. Default to true and won't do aything if `onClose` is undefined.

Also fixes some styling on the Dialog to match the figma design (except the close icon, which just looks way too small in the design, and we were using it bigger anyways)

## Todo

- [ ] Bump version and add tag
