### PR TITLE
feat: generating logic constant template

### DIFF
--- a/build-utils/css/README.md
+++ b/build-utils/css/README.md
@@ -7,10 +7,10 @@ This script is primarily created for generating accessible style constants and c
 
 ## **Generating dynamic constant process overview**
 Sub script `build-utils/css/buildLogicConstants.ts` is primarily created for having a way to generate a constant programmatically with logic and customized jsdocs comments.  
+(**Included script to generate template for generating a content**)  
 **REASON**: Typescript will not read and provide jsdocs info on the spread operators (Ex: `...sthing`), so we can't benefit from jsdocs tag when using typescript key suggestion.  
   
 ### **When you run the script, it will**:
-*BEFORE STARTED, UNTIL WE HAVE A SCRIPT TO GENERATE THE TEMPLATE, YOU MAY NEED TO MANUALLY PUT A FILE WITH SOME REQUIRED FUNCTIONS AND VARIABLES WITH NAMING SYNTAX `_${name}.ts` (WHICH WILL BE EXPLAINED HOW DEEPER BELOW) INTO `build-utils/css/constants/logics`.*  
 1. Read through all the files in `build-utils/css/constants/logics`, class `LogicConstant` in `build-utils/css/class` will:
     - Parse the given file. 
     - Validate the file and throw error message if the file doesn't have specific function or constant.
@@ -21,45 +21,15 @@ Sub script `build-utils/css/buildLogicConstants.ts` is primarily created for hav
 
 ## **How to**:
 ### - Create a logic file
-1. Create a file follow this naming convention `_${fileName}.ts` in `build-utils/css/constants/logics`.
-2. Copy content below and replace `{{CapitalizedFileName}}` with capitalized file name without `_` and extension. And replace `{{FileName}}` with actual file name `_${filename}.ts`.
+1. Run the command below to generate the dummy content for your new dynamic constant logic.
     ```
-    import {
-    ConstantCustomizedComment,
-    ConstantKeyValuePairsType,
-    } from './types/LogicConstantType';
-
-    /** Flag to determine to apply jdocs generation rule from get{{CapitalizedFileName}}ConstantCustomizedComment function below */
-    export const hasJSDocsComment: boolean = true;
-
-    /**
-    * Get jsdocs comment that need to be injected to each {{FileName}} constant with customized comment
-    *
-    * **NOTE**: enable when `hasJSDocsComment` is on
-    * */
-    export const get{{CapitalizedFileName}}ConstantCustomizedComment: ConstantCustomizedComment = ({
-    key,
-    value,
-    }) => {
-    /** Put logic here to generate jsdocs string for each line in constant */
-    return `${key}: ${value}`;
-    };
-
-    /**
-    * Return key/value pairs after applying logic
-    */
-    export const get{{CapitalizedFileName}}ConstantKeyValuePairs: ConstantKeyValuePairsType = () => {
-    const contentArr: Record<string, string> = {};
-
-    /** Put logic here to generate constant key value pairs */
-    
-    return contentArr;
-    };
+    yarn template:logic-constant yourFileName
     ```
+2. The generated file now will be located at `build-utils/css/constants/logics` with name `_yourFileName.ts`.
 3. Put logic of how you want the key/value pair in constant to look like in function `get{{CapitalizedFileName}}ConstantKeyValuePairs`.  
 Ex: 
     ```
-    export const getTestNumberConstantKeyValuePairs: ConstantKeyValuePairsType = () => {
+    export const getYourFileNameConstantKeyValuePairs: ConstantKeyValuePairsType = () => {
         const contentArr: Record<string, string> = {};
 
         /** Put logic here to generate constant key value pairs */
@@ -70,10 +40,10 @@ Ex:
         return contentArr;
     };
     ``` 
-4. Put logic of how you want @jsdocs tag to be generated to look like with each key/value pair in constant in function `getTestNumberConstantCustomizedComment`. Leave it as it is if you want it to use the default one.  
+4. Put logic of how you want @jsdocs tag to be generated to look like with each key/value pair in constant in function `getYourFileNameConstantCustomizedComment`. Leave it as it is if you want it to use the default one.  
 Ex: 
     ```
-    export const getTestNumberConstantCustomizedComment: ConstantCustomizedComment = ({
+    export const getYourFileNameConstantCustomizedComment: ConstantCustomizedComment = ({
         key,
         value,
     }) => {
@@ -82,7 +52,7 @@ Ex:
     };
     ``` 
 5. Turn the flag `hasJSDocsComment` on or off wether to enable showing jsdocs.
-6. Run command `'yarn build:logic-constant'` to generate the file. New files will be generated at `build-utils/css/constants/generated`
+6. Run command `'yarn build:logic-constant'` to generate the file. New files with exact same name will be generated at `build-utils/css/constants/generated`
   
 ### - Import generated file in theme file (`theme.ts` | `_darkTheme.ts`)
 Let's say we have an exported constant `testNumber` in `build-utils/csss/constants/logics/_testNumber.ts` and we want to import that file into `theme.ts`.

--- a/build-utils/css/class/LogicConstant.ts
+++ b/build-utils/css/class/LogicConstant.ts
@@ -145,6 +145,64 @@ export class LogicConstant {
     }
   }
 
+  /** Checking camel case for a text */
+  static camelCaseChecking(text: string) {
+    return !!text && /^[a-z]/.test(text) && !/[\W_]/.test(text);
+  }
+
+  /**
+   *
+   * @param fileName file name that would be generated.
+   *
+   * **Note**:
+   * - Need to be camelCase
+   * - No extension
+   * @return
+   * - `null` when fileName is invalid
+   * - `string` when fileName is valid
+   */
+  static async _generateLogicConstFileContent(
+    fileName: string
+  ): Promise<string> {
+    if (!this.camelCaseChecking(fileName)) {
+      throw Error(
+        'File name needs to be in valid camelCase format with no extension and no underscore.'
+      );
+    }
+    const rootFolder = process.cwd();
+    /** Read the template content */
+    const templateContent = readFileSync(
+      path.resolve(
+        `${rootFolder}/build-utils/css/class/template/logicConstant.tpl`
+      ),
+      { encoding: 'utf-8' }
+    );
+    const newTemplateContent = templateContent
+      .replace(/{{FileName}}/g, fileName)
+      .replace(/{{CapitalizedFileName}}/g, capitalize(fileName));
+
+    return formatTS(newTemplateContent);
+  }
+
+  /**
+   *
+   * @param fileName file name that would be generated.
+   * File name:
+   * - Need to be camelCase
+   * - Have no extension
+   * @note
+   * - Generated file will be located at `build-utils/css/constants/logics` with file name `_${fileName}.ts`.
+   * - It will do nothing if fileName is in wrong format has nothing
+   */
+  static async generateLogicConstantFile(fileName: string) {
+    const fileContent = await this._generateLogicConstFileContent(fileName);
+    const rootFolder = process.cwd();
+    writeFileSync(
+      `${rootFolder}/build-utils/css/constants/logics/_${fileName}.ts`,
+      fileContent
+    );
+  }
+
   /**
    *
    * @param content : file content that need to converted;

--- a/build-utils/css/class/__tests__/LogicConstant.test.ts
+++ b/build-utils/css/class/__tests__/LogicConstant.test.ts
@@ -1,3 +1,5 @@
+import { existsSync, unlinkSync } from 'fs';
+
 import { LogicConstant } from '../LogicConstant';
 
 describe('Make sure transformLogicConstant in LogicConstant work properly', () => {
@@ -34,5 +36,120 @@ export const test = {
   test.each(testCases)(`Case: '$case'`, async ({ case: _case, content }) => {
     const result = await LogicConstant.transformImportedConstant(content);
     expect(result).toMatchSnapshot(_case);
+  });
+});
+
+describe('Make sure `camelCaseChecking` in LogicConstant work properly', () => {
+  type UnitTest = {
+    text: string;
+    expected: boolean;
+  };
+  const testCases: UnitTest[] = [
+    {
+      text: '',
+      expected: false,
+    },
+    {
+      text: 'PasCalCase',
+      expected: false,
+    },
+    {
+      text: 'camelCase',
+      expected: true,
+    },
+    {
+      text: 'camelcase',
+      expected: true,
+    },
+    {
+      text: 'camelCaseWithNumber123',
+      expected: true,
+    },
+    {
+      text: 'just_SnakeCase',
+      expected: false,
+    },
+    {
+      text: 'Mix_SnakeCase_And_PasCal',
+      expected: false,
+    },
+    {
+      text: '123camelCaseWithNumber',
+      expected: false,
+    },
+    {
+      text: 'camelCaseWithNumber123',
+      expected: true,
+    },
+    {
+      text: 'sp3c1alCh@r@ct3rCame',
+      expected: false,
+    },
+  ];
+  test.each(testCases)(
+    `text: $text - expected: $expected`,
+    async ({ text, expected }) => {
+      const result = LogicConstant.camelCaseChecking(text);
+      expect(result).toBe(expected);
+    }
+  );
+});
+
+describe('Make sure `generateLogicConstFileContent` in LogicConstant work properly', () => {
+  test(`Generated template content match snapshot`, async () => {
+    const result = await LogicConstant._generateLogicConstFileContent('space');
+    expect(result).toMatchSnapshot();
+  });
+
+  test(`Passing empty file name to the function`, async () => {
+    try {
+      await LogicConstant._generateLogicConstFileContent('');
+    } catch (err) {
+      if (err instanceof Error) {
+        expect(err.message).toBe(
+          'File name needs to be in valid camelCase format with no extension and no underscore.'
+        );
+      }
+    }
+  });
+});
+
+describe('Make sure `generateLogicConstFile` in LogicConstant work properly', () => {
+  const rootFolder = process.cwd();
+  const fileName = 'testSpaceSnapshot';
+  const filePath = `${rootFolder}/build-utils/css/constants/logics/_${fileName}.ts`;
+
+  afterEach(() => {
+    // clean up the file after generating it
+    if (existsSync(filePath)) {
+      unlinkSync(filePath);
+    }
+  });
+  test(`New file generated at 'build-utils/css/logics'`, async () => {
+    await LogicConstant.generateLogicConstantFile(fileName);
+    const exist = existsSync(filePath);
+    expect(exist).toBe(true);
+  });
+  test(`Passing empty file name to the function`, async () => {
+    try {
+      await LogicConstant.generateLogicConstantFile('');
+    } catch (err) {
+      if (err instanceof Error) {
+        expect(err.message).toBe(
+          'File name needs to be in valid camelCase format with no extension and no underscore.'
+        );
+      }
+    }
+  });
+  test(`Passing invalid file name to the function`, async () => {
+    try {
+      await LogicConstant.generateLogicConstantFile('__invalidFileName');
+    } catch (err) {
+      if (err instanceof Error) {
+        expect(err.message).toBe(
+          'File name needs to be in valid camelCase format with no extension and no underscore.'
+        );
+      }
+    }
   });
 });

--- a/build-utils/css/class/__tests__/__snapshots__/LogicConstant.test.ts.snap
+++ b/build-utils/css/class/__tests__/__snapshots__/LogicConstant.test.ts.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Make sure \`generateLogicConstFileContent\` in LogicConstant work properly Generated template content match snapshot 1`] = `
+"import {
+  ConstantCustomizedComment,
+  ConstantKeyValuePairsType,
+} from './types/LogicConstantType';
+
+/** Flag to determine to apply jdocs generation rule from getSpaceConstantCustomizedComment function below */
+export const hasJSDocsComment: boolean = true;
+
+/**
+ * Get jsdocs comment that need to be injected to each space constant with customized comment
+ *
+ * **NOTE**: only enable when \`hasJSDocsComment\` is on
+ * */
+export const getSpaceConstantCustomizedComment: ConstantCustomizedComment = ({
+  key,
+  value,
+}) => {
+  /** Put logic here to generate jsdocs string for each line in constant */
+  return \`\${key}: \${value}\`;
+};
+
+/**
+ * Return key/value pairs after applying logic
+ */
+export const getSpaceConstantKeyValuePairs: ConstantKeyValuePairsType = () => {
+  const contentArr: Record<string, string> = {};
+
+  /** Put logic here to generate constant key value pairs */
+
+  return contentArr;
+};
+"
+`;
+
 exports[`Make sure transformLogicConstant in LogicConstant work properly Case: 'Has 1 import': Has 1 import 1`] = `
 "export const test = {
   key1: 'value1',

--- a/build-utils/css/class/template/logicConstant.tpl
+++ b/build-utils/css/class/template/logicConstant.tpl
@@ -1,0 +1,31 @@
+import {
+  ConstantCustomizedComment,
+  ConstantKeyValuePairsType,
+} from './types/LogicConstantType';
+
+/** Flag to determine to apply jdocs generation rule from get{{CapitalizedFileName}}ConstantCustomizedComment function below */
+export const hasJSDocsComment: boolean = true;
+
+/**
+ * Get jsdocs comment that need to be injected to each {{FileName}} constant with customized comment
+ *
+ * **NOTE**: only enable when `hasJSDocsComment` is on
+ * */
+export const get{{CapitalizedFileName}}ConstantCustomizedComment: ConstantCustomizedComment = ({
+  key,
+  value,
+}) => {
+  /** Put logic here to generate jsdocs string for each line in constant */
+  return `${key}: ${value}`;
+};
+
+/**
+ * Return key/value pairs after applying logic
+ */
+export const get{{CapitalizedFileName}}ConstantKeyValuePairs: ConstantKeyValuePairsType = () => {
+  const contentArr: Record<string, string> = {};
+
+  /** Put logic here to generate constant key value pairs */
+  
+  return contentArr;
+};

--- a/build-utils/css/generateLogicConstTemplate.ts
+++ b/build-utils/css/generateLogicConstTemplate.ts
@@ -1,0 +1,10 @@
+import { argv } from 'process';
+
+import { LogicConstant } from './class/LogicConstant';
+
+const [, , fileName] = argv;
+if (!fileName) {
+  throw Error('File name not found');
+}
+
+LogicConstant.generateLogicConstantFile(fileName);

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "prebuild:prep:publish": "echo 'building for publishing'",
     "build:prep:publish": "ts-node build-utils/setupPackage.ts",
     "postbuild:prep:publish": "echo 'done building for publishing'",
+    "template:logic-constant": "ts-node build-utils/css/generateLogicConstTemplate.ts",
     "build:logic-constant": "ts-node build-utils/css/buildLogicConstants.ts",
     "test": "jest --watchAll --testPathIgnorePatterns storyshots",
     "test:prod": "jest --testPathIgnorePatterns storyshots",


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR:
- Added a new script to generate a template by just running the command `yarn template:logic-constant fileName`  (make the process easier instead of having to do extra work like copy and paste (like copy and edit the previous file constant, edit file name/file content manually and file content syntax may become inconsistent)
- Added unit tests for the generating template process

## Todo

- [ ] Bump version and add tag
