### PR TITLE
feat(table-row): allow expand with children

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.2.24",
+  "version": "3.2.25",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/table/TableRow.tsx
+++ b/src/components/table/TableRow.tsx
@@ -3,8 +3,13 @@ import React, { ReactNode } from 'react';
 export type TableRowProps = {
   children: ReactNode;
   className?: string;
+  onClick?: () => void;
 };
 
-export const TableRow = ({ children, className }: TableRowProps) => {
-  return <tr className={className}>{children}</tr>;
+export const TableRow = ({ children, className, onClick }: TableRowProps) => {
+  return (
+    <tr className={className} onClick={onClick}>
+      {children}
+    </tr>
+  );
 };

--- a/src/components/table/TableRowCollapse.tsx
+++ b/src/components/table/TableRowCollapse.tsx
@@ -3,18 +3,29 @@ import React, { ReactNode } from 'react';
 import { Collapse } from 'src/components/collapse/Collapse';
 import { TableCell } from 'src/components/table/TableCell';
 import { TableRow } from 'src/components/table/TableRow';
+import { theme } from 'src/styles/constants/theme';
 import styled, { css } from 'styled-components';
 
-import { ButtonProps } from '../button/Button';
 import { ExpandButton } from './ExpandButton';
 
-const StyledTableRow = styled(TableRow)<{ isExpand: boolean }>`
+const StyledTableRow = styled(TableRow)<{
+  isExpand: boolean;
+  isExpandable: boolean;
+}>`
   ${p =>
     p.isExpand &&
     css`
       margin-bottom: 16px;
       td {
         border-bottom: 0;
+      }
+    `}
+  ${p =>
+    p.isExpandable &&
+    css`
+      cursor: pointer;
+      :hover {
+        background: ${theme.grayL80};
       }
     `}
 `;
@@ -31,9 +42,9 @@ const ExpandableCell = styled(TableCell)<{ isExpand: boolean }>`
 `;
 
 export type TableRowCollapseProps = {
-  children: ReactNode;
+  children?: ReactNode;
+  handleExpandClick: () => void;
   isExpand: boolean;
-  handleExpandClick: ButtonProps['onClick'];
   rowContent: ReactNode;
 };
 
@@ -43,19 +54,26 @@ export const TableRowCollapse = ({
   isExpand,
   rowContent,
 }: TableRowCollapseProps) => {
+  const isExpandable = !!children;
   return (
     <>
-      <StyledTableRow isExpand={isExpand}>
+      <StyledTableRow
+        isExpandable={isExpandable}
+        isExpand={isExpand}
+        onClick={() => isExpandable && handleExpandClick()}
+      >
         {rowContent}
         <TableCell align="right">
-          <ExpandButton isExpand={isExpand} onClick={handleExpandClick} />
+          {isExpandable && <ExpandButton isExpand={isExpand} />}
         </TableCell>
       </StyledTableRow>
-      <TableRow>
-        <ExpandableCell colSpan={100} isExpand={isExpand}>
-          <Collapse isExpand={isExpand}>{children}</Collapse>
-        </ExpandableCell>
-      </TableRow>
+      {isExpandable && (
+        <TableRow>
+          <ExpandableCell colSpan={100} isExpand={isExpand}>
+            <Collapse isExpand={isExpand}>{children}</Collapse>
+          </ExpandableCell>
+        </TableRow>
+      )}
     </>
   );
 };

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -19,6 +19,7 @@ import { ImageDuotoneIcon } from 'src/icons/ImageDuotoneIcon';
 import { ImportDuotoneIcon } from 'src/icons/ImportDuotoneIcon';
 import { ShoppingListDuotoneIcon } from 'src/icons/ShoppingListDuotoneIcon';
 import { TruckDuotoneIcon } from 'src/icons/TruckDuotoneIcon';
+import { WarningIcon } from 'src/icons/WarningIcon';
 import { theme } from 'src/styles/constants/theme';
 import styled from 'styled-components';
 
@@ -417,6 +418,25 @@ const Template: Story<
               </Table>
             </ExpandedTableCard>
           </TableRowCollapse>
+          <TableRowCollapse
+            handleExpandClick={() => handleExpandClick(5)}
+            isExpand={expandedRows.includes(5)}
+            rowContent={
+              <>
+                <TableCell colSpan={2}>
+                  <LeftIconLabel>
+                    <RoundedIcon background="orange-l80">
+                      <WarningIcon color="orange-d60" />
+                    </RoundedIcon>
+                    <Text fontWeight="500">No children (cannot expand)</Text>
+                  </LeftIconLabel>
+                </TableCell>
+                <TableCell align="right">
+                  <Text fontWeight="500">$0.00</Text>
+                </TableCell>
+              </>
+            }
+          />
         </TableBody>
         <TableFooter>
           <TableRow>


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR allows expanding the Expandable Table Row when there are children. In addition, the click event is now on the table row instead of the button.

## Todo

- [ ] Bump version and add tag
