### PR TITLE
fix: dialog click events being cancelled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.2.27",
+  "version": "3.2.28",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/dialog/_BaseDialog.tsx
+++ b/src/components/dialog/_BaseDialog.tsx
@@ -99,7 +99,6 @@ export const BaseDialog = ({
               key="dialog"
               width={width || 444}
               onClick={e => {
-                e.preventDefault();
                 e.stopPropagation();
               }}
             >

--- a/src/stories/Dialog.stories.tsx
+++ b/src/stories/Dialog.stories.tsx
@@ -66,6 +66,23 @@ BasicDialog.args = {
   width: 460,
 };
 
+export const WithLink = Template.bind({});
+WithLink.args = {
+  actions: (
+    <>
+      <Button intent="outline">Close</Button>
+      <Button intent="primary">Save</Button>
+    </>
+  ),
+  children: (
+    <div>
+      <a href="http://zonos.com">Here is a link</a>
+    </div>
+  ),
+  label: 'Dialog title',
+  width: 460,
+};
+
 export const WithLeftActions = Template.bind({});
 WithLeftActions.args = {
   leftActions: (


### PR DESCRIPTION
## Description

Fixes an issue I introduced when adding click outside dismissing for dialogs. Clicking links wouldn't work, probably among other things as well.

## Todo

- [x] Bump version and add tag
