### PR TITLE
build(actions): update publish actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,13 +9,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: yarn
-      - run: yarn run build
+          node-version: "14.x"
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
       - run: cd dist && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Description

Didn't like staring at the Publish action waiting for it to finish, so maybe caching dependencies will make it faster.