### PR TITLE
Style/fix button w long content inside short wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.2.28",
+  "version": "3.2.29",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -33,8 +33,8 @@ const StyledSpinnerWrapper = styled.span`
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: ${theme.radiusSm};
-  gap: ${theme.spaceQuarter};
+  border-radius: ${theme.radius4};
+  gap: ${theme.space8};
 `;
 
 const AminoButton = styled.button<ButtonProps<GroupTag>>`
@@ -56,6 +56,7 @@ const AminoButton = styled.button<ButtonProps<GroupTag>>`
   font-family: ${theme.fontSans};
   letter-spacing: normal;
   cursor: pointer;
+  white-space: nowrap;
 
   svg path:not([data-is-secondary-color]) {
     fill: currentColor;


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds `white-space: nowrap;` to the button to always display text in one line since the button height would never change but the width does.
<img width="1115" alt="image" src="https://user-images.githubusercontent.com/17950626/195632671-117ef8c1-b74f-4a2f-bf21-138feba965ec.png">


## Todo

- [x] Bump version and add tag
