### PR TITLE
build(actions): add back registry-url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
+          registry-url: "https://registry.npmjs.org"
           cache: "yarn"
       - run: yarn install --frozen-lockfile
       - run: yarn build


### PR DESCRIPTION
## Description

As stated [here](https://github.com/actions/setup-node/blob/main/action.yml)

The last tag failed to publish, so this should trigger that
