### PR TITLE
fix: overflow auto when fully expanded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.2.29",
+  "version": "3.2.30",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -7,14 +7,16 @@ import { type StyledProps } from '../../types/StyledProps';
 
 const StyledCollapseWrapper = styled.div<StyledCollapseProps>`
   transition: height 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  overflow: hidden;
+  overflow: ${({ $hideOverflow }) => ($hideOverflow ? 'hidden' : 'auto')};
   position: relative;
   min-height: ${({ $collapseSize }) =>
     $collapseSize ? `${$collapseSize}px` : '0px'};
   height: ${({ $height }) => `${$height}px`};
 `;
 
-type StyledCollapseProps = StyledProps<CollapseProps & { height: number }>;
+type StyledCollapseProps = StyledProps<
+  CollapseProps & { height: number; hideOverflow: boolean }
+>;
 
 export type CollapseProps = {
   className?: string;
@@ -29,6 +31,7 @@ export const Collapse = ({
   children,
 }: CollapseProps) => {
   const [height, setHeight] = useState(0);
+  const [hideOverflow, setHideOverflow] = useState(!isExpand);
   const [resizeListener, sizes] = useResizeAware();
 
   useEffect(() => {
@@ -37,14 +40,26 @@ export const Collapse = ({
     } else {
       setHeight(0);
     }
+    setHideOverflow(true);
   }, [isExpand, setHeight, sizes.height]);
+
+  const handleTransitionEnd = () => {
+    if (isExpand) {
+      // Done expanding so safe to show overflow
+      setHideOverflow(false);
+    } else {
+      setHideOverflow(true);
+    }
+  };
 
   return (
     <StyledCollapseWrapper
       className={className}
       $height={height}
       $isExpand={isExpand}
+      $hideOverflow={hideOverflow}
       $collapseSize={collapseSize || 0}
+      onTransitionEnd={handleTransitionEnd}
     >
       <div style={{ position: 'relative' }}>
         {resizeListener}

--- a/src/stories/Collapse/Collapse.stories.tsx
+++ b/src/stories/Collapse/Collapse.stories.tsx
@@ -1,10 +1,11 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Meta, Story } from '@storybook/react/types-6-0';
+import { Button } from 'src/components/button/Button';
 import { Collapse, CollapseProps } from 'src/components/collapse/Collapse';
 import { NavigationItem } from 'src/components/layout/NavigationGroup';
 import { withDesign } from 'storybook-addon-designs';
+import styled from 'styled-components';
 
 const CollapseMeta: Meta = {
   title: 'Amino/Collapse',
@@ -16,42 +17,46 @@ const CollapseMeta: Meta = {
   },
   argTypes: {
     children: {
-      description: 'ReactNode item that need to be collapsed or expanded',
-      type: 'symbol',
+      table: {
+        disable: true,
+      },
     },
     isExpand: {
-      defaultValue: false,
-      type: 'boolean',
-    },
-    collapseSize: {
-      type: 'number',
-      defaultValue: 0,
-    },
-    className: {
-      type: 'string',
+      table: {
+        disable: true,
+      },
     },
   },
 };
 
 export default CollapseMeta;
 
+const CollapseContainer = styled.div`
+  margin: 20px;
+`;
+
 const Template: Story<CollapseProps> = ({
   className,
   children,
-  isExpand,
   collapseSize,
 }) => {
+  const [open, setOpen] = useState(false);
+
   return (
     <>
-      <p>Collapse status: {isExpand ? 'Expanded' : 'Collapsed'}</p>
-      <p>Collapse size: {collapseSize ? `${collapseSize}px` : '0px'}</p>
-      <Collapse
-        className={className}
-        isExpand={isExpand}
-        collapseSize={collapseSize}
-      >
-        {children}
-      </Collapse>
+      <Button onClick={() => setOpen(!open)}>
+        {open ? 'Collapse' : 'Expand'}{' '}
+      </Button>
+      <CollapseContainer>
+        <p>Collapse size: {collapseSize ? `${collapseSize}px` : '0px'}</p>
+        <Collapse
+          className={className}
+          isExpand={open}
+          collapseSize={collapseSize}
+        >
+          {children}
+        </Collapse>
+      </CollapseContainer>
     </>
   );
 };

--- a/src/stories/Collapse/Collapse.stories.tsx
+++ b/src/stories/Collapse/Collapse.stories.tsx
@@ -2,14 +2,17 @@ import React, { useState } from 'react';
 
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { Button } from 'src/components/button/Button';
-import { Collapse, CollapseProps } from 'src/components/collapse/Collapse';
+import {
+  Collapse as CollapseComponent,
+  CollapseProps,
+} from 'src/components/collapse/Collapse';
 import { NavigationItem } from 'src/components/layout/NavigationGroup';
 import { withDesign } from 'storybook-addon-designs';
 import styled from 'styled-components';
 
 const CollapseMeta: Meta = {
   title: 'Amino/Collapse',
-  component: Collapse,
+  component: CollapseComponent,
   decorators: [withDesign],
 
   parameters: {
@@ -49,19 +52,19 @@ const Template: Story<CollapseProps> = ({
       </Button>
       <CollapseContainer>
         <p>Collapse size: {collapseSize ? `${collapseSize}px` : '0px'}</p>
-        <Collapse
+        <CollapseComponent
           className={className}
           isExpand={open}
           collapseSize={collapseSize}
         >
           {children}
-        </Collapse>
+        </CollapseComponent>
       </CollapseContainer>
     </>
   );
 };
-export const Example = Template.bind({});
-Example.args = {
+export const Collapse = Template.bind({});
+Collapse.args = {
   children: (
     <>
       <NavigationItem content="Item 1" isActive />

--- a/src/utils/useResizeAware.tsx
+++ b/src/utils/useResizeAware.tsx
@@ -18,7 +18,7 @@ export type UseResizeAwareProps = [
 /**
  * Hook to detect element when it changes in size (height / width)
  * @NOTE Make sure the measured element has `position != initial`
- * (`relative`, `absolute`, or `fixed` will work))
+ * (`relative`, `absolute`, or `fixed` will work)
  * @example
  * import React from 'react';
   import { useResizeAware } from 'src/utils/useResizeAware';


### PR DESCRIPTION
## Description

Fixes an issue with the `Collapse` component where `overflow: hidden` was causing box shadows (and anything outside the components bounding box) to be hidden.

Also made the Collapse story slightly nicer.

## Todo

- [ ] Bump version and add tag
