### PR TITLE
Fix/h section collapse padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.2.35",
+  "version": "3.2.36",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -33,17 +33,19 @@ export const Collapse = ({
   const [height, setHeight] = useState(0);
   const [hideOverflow, setHideOverflow] = useState(!isExpand);
   const [resizeListener, sizes] = useResizeAware();
+  console.log(height, hideOverflow);
 
   useEffect(() => {
+    setHideOverflow(true);
     if (sizes.height && isExpand) {
       setHeight(sizes.height);
     } else {
       setHeight(0);
     }
-    setHideOverflow(true);
-  }, [isExpand, setHeight, sizes.height]);
+  }, [isExpand, setHeight, sizes.height, hideOverflow]);
 
   const handleTransitionEnd = () => {
+    console.log('transition ended', hideOverflow, isExpand);
     if (isExpand) {
       // Done expanding so safe to show overflow
       setHideOverflow(false);

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -33,7 +33,6 @@ export const Collapse = ({
   const [height, setHeight] = useState(0);
   const [hideOverflow, setHideOverflow] = useState(!isExpand);
   const [resizeListener, sizes] = useResizeAware();
-  console.log(height, hideOverflow);
 
   useEffect(() => {
     setHideOverflow(true);
@@ -45,7 +44,6 @@ export const Collapse = ({
   }, [isExpand, setHeight, sizes.height, hideOverflow]);
 
   const handleTransitionEnd = () => {
-    console.log('transition ended', hideOverflow, isExpand);
     if (isExpand) {
       // Done expanding so safe to show overflow
       setHideOverflow(false);

--- a/src/components/dialog/_BaseDialog.tsx
+++ b/src/components/dialog/_BaseDialog.tsx
@@ -98,6 +98,7 @@ export const BaseDialog = ({
               key="dialog"
               width={width || 444}
               onClick={e => {
+                // Prevent dialog from closing when clicking in the dialog
                 e.stopPropagation();
               }}
             >

--- a/src/components/section/HSection.tsx
+++ b/src/components/section/HSection.tsx
@@ -7,24 +7,19 @@ import styled from 'styled-components';
 
 import { Button } from '../button/Button';
 import { Collapse } from '../collapse/Collapse';
-import { SectionHeader } from './_SectionHeader';
+import { Text } from '../text/Text';
 import { SectionInnerWrapper } from './_SectionInnerWrapper';
 import { SectionSubheader } from './_SectionSubheader';
 
 const StyledSectionWrapper = styled(HStack)`
-  margin-bottom: ${theme.spaceDouble};
+  padding: ${theme.space8};
+  margin-bottom: ${theme.space40};
   grid-template-columns: 1fr 2fr;
 `;
 
-const StyledHeader = styled.div`
-  position: relative;
-  display: inline-block;
-`;
-
 const StyledCollapseIndicator = styled(Button)`
-  position: absolute;
-  left: 100%;
-  top: -2px;
+  position: relative;
+  margin-left: ${theme.space4};
   transition: 0.2s all ease;
   background: transparent;
   &:active,
@@ -34,9 +29,19 @@ const StyledCollapseIndicator = styled(Button)`
     color: ${theme.grayD40};
   }
 
-  .collapse & {
+  &.collapse {
     transform: rotate(-90deg);
   }
+`;
+
+const StyledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const TitleDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
 `;
 
 export type HSectionProps = {
@@ -75,21 +80,28 @@ export const HSection = ({
     <StyledSectionWrapper className={className || ''}>
       {label && (
         <SectionInnerWrapper>
-          <SectionHeader>
-            <div>
-              <StyledHeader className={collapse ? 'collapse' : ''}>
-                {label}{' '}
-                {collapsable && (
-                  <StyledCollapseIndicator
-                    size="sm"
-                    icon={<ChevronDownSolidIcon size={20} />}
-                    onClick={() => setCollapse(!collapse)}
-                  />
-                )}
-              </StyledHeader>
-            </div>
-            <SectionSubheader>{sublabel}</SectionSubheader>
-          </SectionHeader>
+          <StyledDiv>
+            {collapsable ? (
+              <TitleDiv
+                role="button"
+                tabIndex={0}
+                onClick={() => setCollapse(!collapse)}
+                onKeyDown={() => null}
+              >
+                <Text type="title">{label}</Text>
+                <StyledCollapseIndicator
+                  className={collapse ? 'collapse' : ''}
+                  size="sm"
+                  icon={<ChevronDownSolidIcon size={24} />}
+                  onClick={() => setCollapse(!collapse)}
+                />
+              </TitleDiv>
+            ) : (
+              <Text type="title">{label}</Text>
+            )}
+
+            {sublabel && <SectionSubheader>{sublabel}</SectionSubheader>}
+          </StyledDiv>
         </SectionInnerWrapper>
       )}
       {renderContent()}

--- a/src/stories/HSection.stories.tsx
+++ b/src/stories/HSection.stories.tsx
@@ -3,11 +3,15 @@ import React from 'react';
 import { useEffect, useState } from '@storybook/addons';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { Button } from 'src/components/button/Button';
+import { Card } from 'src/components/card/Card';
+import { Checkbox } from 'src/components/checkbox/Checkbox';
 import { Input } from 'src/components/input/Input';
 import { HSection, HSectionProps } from 'src/components/section/HSection';
 import { VStack } from 'src/components/stack/VStack';
 import { Text } from 'src/components/text/Text';
 import { withDesign } from 'storybook-addon-designs';
+import styled from 'styled-components';
+import { v4 } from 'uuid';
 
 const HSectionMeta: Meta = {
   title: 'Amino/HSection',
@@ -65,22 +69,22 @@ const Template: Story<HSectionProps> = (props: HSectionProps) => {
 
 export const Basic = Template.bind({});
 Basic.args = {
-  children: `Lorem ipsum dolor sit amet consectetur adipisicing elit. 
-  Iure minima tenetur ratione deserunt beatae a et, aliquam, nesciunt 
-  illo asperiores quasi! Neque, praesentium. 
+  children: `Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  Iure minima tenetur ratione deserunt beatae a et, aliquam, nesciunt
+  illo asperiores quasi! Neque, praesentium.
   Itaque blanditiis corporis incidunt doloribus assumenda eos.`,
   label: 'My HSection',
 };
 
 export const Collapsable = Template.bind({});
 Collapsable.args = {
-  children: `Lorem ipsum dolor sit amet consectetur adipisicing elit. 
-  Iure minima tenetur ratione deserunt beatae a et, aliquam, nesciunt 
-  illo asperiores quasi! Neque, praesentium. 
+  children: `Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  Iure minima tenetur ratione deserunt beatae a et, aliquam, nesciunt
+  illo asperiores quasi! Neque, praesentium.
   Itaque blanditiis corporis incidunt doloribus assumenda eos.`,
-  sublabel: `SUB TITLE Lorem ipsum dolor sit amet consectetur adipisicing elit. 
-  Iure minima tenetur ratione deserunt beatae a et, aliquam, nesciunt 
-  illo asperiores quasi! Neque, praesentium. 
+  sublabel: `SUB TITLE Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  Iure minima tenetur ratione deserunt beatae a et, aliquam, nesciunt
+  illo asperiores quasi! Neque, praesentium.
   Itaque blanditiis corporis incidunt doloribus assumenda eos.`,
   label: 'My HSection',
   collapsable: true,
@@ -88,15 +92,80 @@ Collapsable.args = {
 
 export const CollapsedByDefault = Template.bind({});
 CollapsedByDefault.args = {
-  children: `Lorem ipsum dolor sit amet consectetur adipisicing elit. 
-  Iure minima tenetur ratione deserunt beatae a et, aliquam, nesciunt 
-  illo asperiores quasi! Neque, praesentium. 
+  children: `Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  Iure minima tenetur ratione deserunt beatae a et, aliquam, nesciunt
+  illo asperiores quasi! Neque, praesentium.
   Itaque blanditiis corporis incidunt doloribus assumenda eos.`,
-  sublabel: `SUB TITLE Lorem ipsum dolor sit amet consectetur adipisicing elit. 
-  Iure minima tenetur ratione deserunt beatae a et, aliquam, nesciunt 
-  illo asperiores quasi! Neque, praesentium. 
+  sublabel: `SUB TITLE Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  Iure minima tenetur ratione deserunt beatae a et, aliquam, nesciunt
+  illo asperiores quasi! Neque, praesentium.
   Itaque blanditiis corporis incidunt doloribus assumenda eos.`,
   label: 'My HSection',
   collapsable: true,
   collapseByDefault: true,
+};
+
+const StyledVStack = styled(VStack)`
+  max-width: 600px;
+`;
+
+export const VariableList = () => {
+  const [collapsable, setCollapsable] = useState(true);
+  const [items, setItems] = useState<string[]>(['Couch']);
+
+  const removeItem = (index: number) => {
+    setItems(prevIems => {
+      const newItems = [...prevIems];
+      newItems.splice(index, 1);
+      return newItems;
+    });
+  };
+
+  const addItem = () => {
+    setItems(prevItems => [...prevItems, v4()]);
+  };
+
+  return (
+    <StyledVStack>
+      <Checkbox
+        label="Collapsable"
+        checked={collapsable}
+        onChange={e => setCollapsable(e.valueOf())}
+      />
+      <Button onClick={() => setItems([])}>Clear</Button>
+      <HSection label="Variable length list" collapsable={collapsable}>
+        <Input label="No padding input" onChange={() => null} value="value" />
+        <VStack>
+          {items.map((item, idx) => (
+            <Card
+              key={item}
+              label={item}
+              actions={<Button onClick={() => removeItem(idx)}>Remove</Button>}
+            >
+              <Input label="An input" onChange={() => null} value="value" />
+            </Card>
+          ))}
+          <Button onClick={() => addItem()}>Add item</Button>
+        </VStack>
+      </HSection>
+      <HSection
+        label="Variable length list"
+        sublabel="With a sublabel"
+        collapsable={collapsable}
+      >
+        <VStack>
+          {items.map((item, idx) => (
+            <Card
+              key={item}
+              label={item}
+              actions={<Button onClick={() => removeItem(idx)}>Remove</Button>}
+            >
+              <Input label="An input" onChange={() => null} value="value" />
+            </Card>
+          ))}
+          <Button onClick={() => addItem()}>Add item</Button>
+        </VStack>
+      </HSection>
+    </StyledVStack>
+  );
 };

--- a/src/stories/HStack.stories.tsx
+++ b/src/stories/HStack.stories.tsx
@@ -8,18 +8,17 @@ import { HStack } from 'src/components/stack/HStack';
 import { StackProps } from 'src/components/stack/Stack';
 import { IOption } from 'src/types/IOption';
 
-type StoryProps = StackProps & { numberOfChildren: number };
-
-const HStackMeta: Meta<StoryProps> = {
+const HStackMeta: Meta = {
   title: 'Amino/HStack',
   component: HStack,
-  subcomponents: { Select },
   args: {
     numberOfChildren: 4,
   },
 };
 
 export default HStackMeta;
+
+type StoryProps = StackProps & { numberOfChildren: number };
 
 const options = [
   'Nope',

--- a/src/stories/VSection.stories.tsx
+++ b/src/stories/VSection.stories.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { Button } from 'src/components/button/Button';
+import { Input } from 'src/components/input/Input';
 import { ListItem } from 'src/components/list-item/ListItem';
 import { VSection, VSectionProps } from 'src/components/section/VSection';
 import { VStack } from 'src/components/stack/VStack';
 import { CartIcon } from 'src/icons/CartIcon';
 import { withDesign } from 'storybook-addon-designs';
+import styled from 'styled-components';
 
 const VSectionMeta: Meta = {
   title: 'Amino/VSection',
@@ -20,9 +22,35 @@ const Template: Story<VSectionProps> = (props: VSectionProps) => (
   <VSection {...props} />
 );
 
+const StyledDiv = styled.div`
+  border: 1px solid black;
+`;
+
 export const BasicVSection = Template.bind({});
 BasicVSection.args = {
-  children: 'VSection contents',
+  children: (
+    <StyledDiv>
+      <h2>VSection Contents</h2>
+      <p>
+        Bacon ipsum dolor amet salami bresaola flank burgdoggen strip steak.
+        Meatball beef ribs hamburger, porchetta sirloin turkey frankfurter
+        landjaeger pig t-bone. Pork chop turkey kevin sirloin short loin strip
+        steak. Tail spare ribs porchetta pancetta tri-tip shoulder short loin
+        prosciutto turkey bresaola landjaeger leberkas chislic boudin. Meatloaf
+        strip steak cupim pig, shankle short loin hamburger corned beef tongue.
+        Chuck shankle tongue drumstick flank, pastrami buffalo ham short loin
+        porchetta meatloaf andouille alcatra. Ham porchetta buffalo biltong,
+        turducken capicola tenderloin picanha hamburger bacon turkey short loin.
+        Sausage shoulder tongue jerky corned beef, chicken tenderloin swine
+        venison andouille bacon shank ground round. Short loin drumstick jerky
+        swine, corned beef sausage kevin chuck sirloin chislic leberkas. Boudin
+        doner beef ribs brisket pastrami pork belly turkey frankfurter, flank
+        leberkas spare ribs kevin. Pig tenderloin pastrami, turducken sausage
+        ham ball tip pork ham hock brisket salami. Chicken picanha salami, rump
+        frankfurter ground round pork belly kevin.
+      </p>
+    </StyledDiv>
+  ),
   sublabel: 'Sublabel',
   label: 'My VSection',
 };
@@ -36,13 +64,16 @@ BasicVSection.parameters = {
 export const VSectionWithActions = Template.bind({});
 VSectionWithActions.args = {
   children: (
-    <VStack>
-      <ListItem
-        decorator={<CartIcon />}
-        label="**** 1234"
-        subtitle="processed with Stripe"
-      />
-    </VStack>
+    <>
+      <Input label="An input" onChange={() => null} value="value" />
+      <VStack>
+        <ListItem
+          decorator={<CartIcon />}
+          label="**** 1234"
+          subtitle="processed with Stripe"
+        />
+      </VStack>
+    </>
   ),
   label: 'Payment',
   sublabel: 'Sublabel',

--- a/src/stories/VStack.stories.tsx
+++ b/src/stories/VStack.stories.tsx
@@ -5,12 +5,10 @@ import { Button } from 'src/components/button/Button';
 import { Card } from 'src/components/card/Card';
 import { StackProps } from 'src/components/stack/Stack';
 import { VStack } from 'src/components/stack/VStack';
-import { withDesign } from 'storybook-addon-designs';
 
 const VStackMeta: Meta = {
   title: 'Amino/VStack',
   component: VStack,
-  decorators: [withDesign],
   args: {
     numberOfChildren: 4,
   },


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds some padding for HSections so input borders aren't cut off (horizontal padding mostly) . It also attempts to fix some weird issues with a scrollbar showing momentarily in a Collapse. 

At some point the scrollbar was showing up again and I don't remember changing anything, but I can't get it to show up again (by adding items to the HSection list).

Also moved the HStack story out of it's own Stack folder because it was messing up the alphabetization.

## Todo

- [x] Bump version and add tag
