### PR TITLE
refactor: strongly type for countryselect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/select/CountryMultiSelect.tsx
+++ b/src/components/select/CountryMultiSelect.tsx
@@ -70,21 +70,21 @@ export interface CountryMultiSelectProps<
   components?: SelectComponentsConfig<Option, IsMulti, Group>;
   icon?: ReactNode;
   label?: string;
-  onChange: (countryCodes: string[]) => void;
-  countryOptions: ICountryOption[];
+  onChange: (countryCodes: Option['value'][]) => void;
+  countryOptions: ICountryOption<Option['value']>[];
   styles?: StylesConfig<Option, IsMulti, Group>;
   unavailableCountries: IUnavailableCountry[];
-  value: string[];
+  value: Option['value'][];
 }
 
-export const CountryMultiSelect = ({
+export const CountryMultiSelect = <T extends string>({
   label = 'Select countries',
   countryOptions,
   onChange,
   unavailableCountries,
   value,
   ...props
-}: CountryMultiSelectProps) => {
+}: CountryMultiSelectProps<IOption<T>>) => {
   const countries = countryOptions.map(option => {
     const unavailableCountry = unavailableCountries.find(
       x => x.code === option.code

--- a/src/components/select/CountrySelect.tsx
+++ b/src/components/select/CountrySelect.tsx
@@ -3,20 +3,25 @@ import { ICountryOption } from 'src/types/ICountry';
 
 import { Select, SelectProps } from './Select';
 
-type CountrySelectType = {
+type CountrySelectType<T extends string> = {
   autoFocus?: SelectProps['autoFocus'];
-  countryOptions: ICountryOption[];
-  filter?: (country: ICountryOption) => boolean;
+  countryOptions: ICountryOption<T>[];
+  filter?: (country: ICountryOption<T>) => boolean;
   label?: string;
-  onChange: SelectProps['onChange'];
+  onChange: SelectProps<ICountryOption<T>>['onChange'];
   placeholder?: string;
-  value: string | null;
+
+  value: T | null;
 };
 
-export type CountrySelectProps = CountrySelectType &
-  Omit<SelectProps, keyof CountrySelectType | 'options'>;
+export type CountrySelectProps<T extends string = string> =
+  CountrySelectType<T> &
+    Omit<
+      SelectProps<ICountryOption<T>>,
+      keyof CountrySelectType<T> | 'options'
+    >;
 
-export const CountrySelect = ({
+export const CountrySelect = <T extends string>({
   autoFocus,
   countryOptions,
   filter = Boolean,
@@ -25,17 +30,15 @@ export const CountrySelect = ({
   placeholder,
   value,
   ...props
-}: CountrySelectProps) => {
-  const filteredOptions = countryOptions
-    .map(option =>
-      filter(option)
-        ? {
-            ...option,
-            icon: <FlagIcon iconScale="small" code={option.code as IFlag} />,
-          }
-        : null
-    )
-    .filter(Boolean) as ICountryOption[];
+}: CountrySelectProps<T>) => {
+  const filteredOptions: ICountryOption<T>[] = countryOptions.flatMap(option =>
+    filter(option)
+      ? {
+          ...option,
+          icon: <FlagIcon iconScale="small" code={option.code as IFlag} />,
+        }
+      : []
+  );
 
   const selected = filteredOptions.filter(x => x.value === value);
   const firstCountry = selected.find(Boolean);

--- a/src/components/select/__stories__/CountryMultiSelect.stories.tsx
+++ b/src/components/select/__stories__/CountryMultiSelect.stories.tsx
@@ -5,6 +5,7 @@ import {
   CountryMultiSelect,
   CountryMultiSelectProps,
 } from 'src/components/select/CountryMultiSelect';
+import { ICountryOption } from 'src/types/ICountry';
 import styled from 'styled-components';
 
 import { getCountryUrls } from './getCountryUrls.stories';
@@ -13,6 +14,8 @@ import { useCountryOptions } from './useCountryOptions.stories';
 const StyledWrapper = styled.div`
   width: 412px;
 `;
+
+type RandomCountryCode = 'AD' | 'AE' | 'AF' | 'AG' | 'AI' | 'AL' | 'AT';
 
 const CountryMultiSelectMeta: Meta = {
   component: CountryMultiSelect,
@@ -35,14 +38,26 @@ const CountryMultiSelectTemplate: Story<CountryMultiSelectProps> = ({
   const countryOptions = useCountryOptions({
     dashboardUrl,
   });
+  const [typedValue, setTypedValue] = useState<RandomCountryCode[]>([]);
+  const stronglyTypedCountries =
+    countryOptions as ICountryOption<RandomCountryCode>[];
   return (
-    <CountryMultiSelect
-      {...props}
-      countryOptions={countryOptions}
-      onChange={setValue}
-      unavailableCountries={[{ code: 'DZ', message: '(restricted)' }]}
-      value={value}
-    />
+    <>
+      <CountryMultiSelect
+        {...props}
+        countryOptions={countryOptions}
+        onChange={setValue}
+        unavailableCountries={[{ code: 'DZ', message: '(restricted)' }]}
+        value={value}
+      />
+      {/* Check for correctly returning type for onChange and value when there is strongly typed `countryOptions` passed in */}
+      <CountryMultiSelect
+        countryOptions={stronglyTypedCountries}
+        onChange={setTypedValue}
+        unavailableCountries={[{ code: 'DZ', message: '(restricted)' }]}
+        value={typedValue}
+      />
+    </>
   );
 };
 

--- a/src/components/select/__stories__/CountrySelect.stories.tsx
+++ b/src/components/select/__stories__/CountrySelect.stories.tsx
@@ -5,6 +5,7 @@ import {
   CountrySelect,
   CountrySelectProps,
 } from 'src/components/select/CountrySelect';
+import { ICountryOption } from 'src/types/ICountry';
 import styled from 'styled-components';
 
 import { getCountryUrls } from './getCountryUrls.stories';
@@ -13,6 +14,8 @@ import { useCountryOptions } from './useCountryOptions.stories';
 const StyledWrapper = styled.div`
   width: 412px;
 `;
+
+type RandomCountryCode = 'AD' | 'AE' | 'AF' | 'AG' | 'AI' | 'AL' | 'AT';
 
 const CountrySelectMeta: Meta = {
   component: CountrySelect,
@@ -33,13 +36,24 @@ const CountrySelectTemplate: Story<CountrySelectProps> = ({ ...props }) => {
   const countryOptions = useCountryOptions({
     dashboardUrl,
   });
+  const [typedValue, setTypedValue] = useState<RandomCountryCode | null>(null);
+  const stronglyTypedCountries =
+    countryOptions as ICountryOption<RandomCountryCode>[];
   return (
-    <CountrySelect
-      {...props}
-      countryOptions={countryOptions}
-      onChange={option => setValue(option?.value || null)}
-      value={value}
-    />
+    <>
+      <CountrySelect
+        {...props}
+        countryOptions={countryOptions}
+        onChange={option => setValue(option?.value || null)}
+        value={value}
+      />
+      {/* Check for correctly returning type for onChange and value when there is strongly typed `countryOptions` passed in */}
+      <CountrySelect
+        countryOptions={stronglyTypedCountries}
+        onChange={option => setTypedValue(option?.value || null)}
+        value={typedValue}
+      />
+    </>
   );
 };
 

--- a/src/types/ICountry.ts
+++ b/src/types/ICountry.ts
@@ -29,7 +29,7 @@ export interface ICountry<CountryCode extends string = string> {
 }
 export interface ICountryOption<CountryCode extends string = string>
   extends ICountry<CountryCode>,
-    IOption {
+    IOption<CountryCode> {
   phoneCode: string[];
 }
 export interface IRegionCountryOption {

--- a/src/utils/prepRegionCountryOptions.ts
+++ b/src/utils/prepRegionCountryOptions.ts
@@ -1,6 +1,8 @@
 import { ICountryOption, regions } from 'src/types/ICountry';
 
-export const prepRegionCountryOptions = (countries: ICountryOption[]) =>
+export const prepRegionCountryOptions = <T extends string = string>(
+  countries: ICountryOption<T>[]
+) =>
   regions.map(region => ({
     label: region,
     options: countries.filter(x => x.region === region),


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR:
- Improve `CountrySelect` and `CountryMultiSelect` to provide more strongly typed data.
**Ex**: If some strongly typed `RandomCountryCode` variables are passed in `countryOptions`, `onChange` and `value` should give the correct type based on the `countryOptions` variables, which is `RandomCountryCode` and not just primitive `string` type.
![image](https://user-images.githubusercontent.com/17950626/215811103-eebff262-169b-4d9a-b4e3-10e905898c2a.png)
![image](https://user-images.githubusercontent.com/17950626/215811263-8d166dde-20fa-4c46-985e-8bb543494e62.png)


## Todo

- [x] Bump version and add tag
