### PR TITLE
style(tooltip): add custom background & open prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.18",
+  "version": "3.4.19",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -8,6 +8,7 @@ import MuiTooltip, {
 import { VStack } from 'src/components/stack/VStack';
 import { Text } from 'src/components/text/Text';
 import { theme } from 'src/styles/constants/theme';
+import { Color } from 'src/types';
 import styled from 'styled-components';
 
 const StyledVStack = styled(VStack)`
@@ -37,35 +38,47 @@ const ChildWrapper = styled.div`
 `;
 
 export type TooltipProps = {
+  background?: Color;
   children: ReactNode;
   className?: string;
+  open?: boolean;
   showTooltip: boolean;
   subtitle: ReactNode | string | null;
   tag?: 'div' | 'span';
   title?: string;
 };
 
-const StyledTooltip = muiStyled(({ className, ...props }: MuiTooltipProps) => (
-  <MuiTooltip {...props} classes={{ popper: className }} />
-))(() => ({
+const StyledTooltip = muiStyled(
+  ({
+    className,
+    ...props
+  }: MuiTooltipProps & Pick<TooltipProps, 'background'>) => (
+    <MuiTooltip {...props} classes={{ popper: className }} />
+  )
+)(({ background }) => ({
   [`& .${tooltipClasses.tooltip}`]: {
-    backgroundColor: '#0C0C0D',
+    backgroundColor: background ? theme[background] : '#0C0C0D',
     boxShadow: theme.v3ShadowLarge,
   },
 }));
 
 export const Tooltip = ({
+  background,
   className,
   children,
   showTooltip,
   subtitle,
   tag,
   title,
+  open,
 }: TooltipProps) => {
   if (showTooltip) {
+    console.log(background);
     return (
       <StyledTooltip
+        background={background}
         className={className}
+        open={open}
         title={
           <StyledVStack spacing="space-quarter">
             {title && (

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -73,7 +73,6 @@ export const Tooltip = ({
   open,
 }: TooltipProps) => {
   if (showTooltip) {
-    console.log(background);
     return (
       <StyledTooltip
         background={background}

--- a/src/components/tooltip/__stories__/Tooltip.stories.tsx
+++ b/src/components/tooltip/__stories__/Tooltip.stories.tsx
@@ -59,6 +59,9 @@ const VWrapper = styled.div`
 
 export default ButtonMeta;
 
+type ButtonPropWithTooltipOption = Omit<ButtonProps, 'background'> &
+  Pick<TooltipProps, 'background'>;
+
 const HeadingTooltip = ({
   children,
   subtitle = 'This is an example of a tooltip with a heading. Tooltips with a heading can have three lines total.',
@@ -96,17 +99,20 @@ const WithoutHeadingTooltip = ({
   </Tooltip>
 );
 
-const TopRow = (props: ButtonProps) => (
+const TopRow = ({ background, ...props }: ButtonPropWithTooltipOption) => (
   <>
-    <HeadingTooltip>
+    <HeadingTooltip background={background}>
       <Button {...props}>Has heading</Button>
     </HeadingTooltip>
-    <WithoutHeadingTooltip subtitle="This example shows a tooltip with enough characters to fill an alphabet soup when you are sick and then share some with your friends, so it should be truncated.">
+    <WithoutHeadingTooltip
+      background={background}
+      subtitle="This example shows a tooltip with enough characters to fill an alphabet soup when you are sick and then share some with your friends, so it should be truncated."
+    >
       <Button {...props} iconRight>
         Without heading truncated subtitle
       </Button>
     </WithoutHeadingTooltip>
-    <WithoutHeadingTooltip>
+    <WithoutHeadingTooltip background={background}>
       <StyledButton {...props} tag="div" onClick={e => e.preventDefault()}>
         Without heading
       </StyledButton>
@@ -117,8 +123,9 @@ const TopRow = (props: ButtonProps) => (
 const BottomRow = ({
   toggleCoversheet,
   toggleDialog,
+  background,
   ...props
-}: ButtonProps & {
+}: ButtonPropWithTooltipOption & {
   toggleCoversheet: () => void;
   toggleDialog: () => void;
 }) => {
@@ -127,6 +134,7 @@ const BottomRow = ({
   return (
     <>
       <Tooltip
+        background={background}
         showTooltip
         subtitle={
           <VStack>
@@ -141,6 +149,7 @@ const BottomRow = ({
         </StyledButton>
       </Tooltip>
       <Tooltip
+        background={background}
         showTooltip
         subtitle={
           <VStack>
@@ -195,7 +204,7 @@ const BottomRow = ({
           }}
         />
       ) : (
-        <HeadingTooltip>
+        <HeadingTooltip background={background}>
           <Button {...props} onClick={() => setShowSelect(true)}>
             Test select z-index
           </Button>
@@ -205,7 +214,10 @@ const BottomRow = ({
   );
 };
 
-const Template: Story<ButtonProps> = props => {
+const Template: Story<ButtonPropWithTooltipOption> = ({
+  background,
+  ...props
+}) => {
   const [coversheetOpen, setCoversheetOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -214,10 +226,11 @@ const Template: Story<ButtonProps> = props => {
       <VWrapper>
         <VStack spacing="space-quarter">
           <HWrapper>
-            <TopRow {...props} />
+            <TopRow background={background} {...props} />
           </HWrapper>
           <HWrapper>
             <BottomRow
+              background={background}
               {...props}
               toggleCoversheet={() => setCoversheetOpen(!coversheetOpen)}
               toggleDialog={() => setDialogOpen(!dialogOpen)}
@@ -226,10 +239,11 @@ const Template: Story<ButtonProps> = props => {
         </VStack>
         <VStack spacing="space-quarter">
           <HWrapper>
-            <TopRow {...props} disabled />
+            <TopRow background={background} {...props} disabled />
           </HWrapper>
           <HWrapper>
             <BottomRow
+              background={background}
               {...props}
               disabled
               toggleCoversheet={() => setCoversheetOpen(!coversheetOpen)}
@@ -239,10 +253,11 @@ const Template: Story<ButtonProps> = props => {
         </VStack>
         <VStack spacing="space-quarter">
           <HWrapper>
-            <TopRow {...props} loading />
+            <TopRow background={background} {...props} loading />
           </HWrapper>
           <HWrapper>
             <BottomRow
+              background={background}
               {...props}
               loading
               toggleCoversheet={() => setCoversheetOpen(!coversheetOpen)}
@@ -253,7 +268,7 @@ const Template: Story<ButtonProps> = props => {
       </VWrapper>
       <TransparentCoverSheet
         actions={
-          <HeadingTooltip>
+          <HeadingTooltip background={background}>
             <Button {...props} disabled>
               Has heading
             </Button>
@@ -273,7 +288,7 @@ const Template: Story<ButtonProps> = props => {
       </TransparentCoverSheet>
       <Dialog
         actions={
-          <HeadingTooltip>
+          <HeadingTooltip background={background}>
             <Button {...props} disabled>
               Has heading
             </Button>


### PR DESCRIPTION
## Jira issue

<!-- [Jira issue description](url) -->
<!-- Example:
[3106 - Loup Charmant - Need dashboard switched from Hello](https://myzonos.atlassian.net/browse/DM-550)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
Storybook url:
- [Tooltip w orange background](https://amino-b9bba0mop-zonos.vercel.app/?path=/story/amino-tooltip--default&args=background:orange400)

This PR:
- add `open` prop to easily manipulate the open state
- custom `background` to the tooltip
<img width="1263" alt="image" src="https://user-images.githubusercontent.com/17950626/216661475-911f1ae1-aaf1-4fb3-9ee5-ee53cff2fa78.png">


## Todo

- [ ] Bump version and add tag
