### PR TITLE
fix: collapse initial state animation and add to story to show

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.19",
+  "version": "3.4.20",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/collapse/__stories__/Collapse.stories.tsx
+++ b/src/components/collapse/__stories__/Collapse.stories.tsx
@@ -33,6 +33,13 @@ export default CollapseMeta;
 
 const CollapseContainer = styled.div`
   margin: 20px;
+  display: flex;
+  gap: 40px;
+`;
+
+const StyledCollapseComponent = styled(CollapseComponent)`
+  border: 1px solid grey;
+  border-radius: 6px;
 `;
 
 const Template: Story<CollapseProps> = ({
@@ -40,22 +47,41 @@ const Template: Story<CollapseProps> = ({
   children,
   collapseSize,
 }) => {
-  const [open, setOpen] = useState(false);
+  const [open1, setOpen1] = useState(true);
+  const [open2, setOpen2] = useState(false);
 
   return (
     <>
-      <Button onClick={() => setOpen(!open)}>
-        {open ? 'Collapse' : 'Expand'}{' '}
+      <Button
+        onClick={() => {
+          setOpen1(!open1);
+          setOpen2(!open2);
+        }}
+      >
+        Toggle
       </Button>
       <CollapseContainer>
         <p>Collapse size: {collapseSize ? `${collapseSize}px` : '0px'}</p>
-        <CollapseComponent
-          className={className}
-          isExpand={open}
-          collapseSize={collapseSize}
-        >
-          {children}
-        </CollapseComponent>
+        <div>
+          Open by default
+          <StyledCollapseComponent
+            className={className}
+            isExpand={open1}
+            collapseSize={collapseSize}
+          >
+            {children}
+          </StyledCollapseComponent>
+        </div>
+        <div>
+          Closed by default
+          <StyledCollapseComponent
+            className={className}
+            isExpand={open2}
+            collapseSize={collapseSize}
+          >
+            {children}
+          </StyledCollapseComponent>
+        </div>
       </CollapseContainer>
     </>
   );


### PR DESCRIPTION
## Jira issue

<!-- [Jira issue description](url) -->
[MdxCollapse animates open instead of just being open right on page load](https://myzonos.atlassian.net/browse/DOCS-292)

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes an issue where the Collapse would animate the initial state if it started open. I also made it `opacity:0` because if it ever had borders and such it would still show while collapsed.

## Todo

- [x] Bump version and add tag
