### PR TITLE
fix: add button type 'button' everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.22",
+  "version": "3.4.23",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/drop-zone/DropZone.tsx
+++ b/src/components/drop-zone/DropZone.tsx
@@ -169,7 +169,7 @@ export const DropZone = ({
       <InstructionTextWrapper>
         <Text type="label">
           {instructionText} or{' '}
-          <BrowseButton onClick={open} disabled={disabled}>
+          <BrowseButton type="button" onClick={open} disabled={disabled}>
             <Text type="label" color="blue600">
               browse
             </Text>

--- a/src/components/input/input-type/_DateInput.tsx
+++ b/src/components/input/input-type/_DateInput.tsx
@@ -93,6 +93,7 @@ export const DateInput = ({
           suffix || (
             <StyledActionWrapper>
               <StyledButtonAction
+                type="button"
                 onClick={() => {
                   inputRef.current?.showPicker();
                   inputRef.current?.dispatchEvent(

--- a/src/components/input/input-type/_NumberInput.tsx
+++ b/src/components/input/input-type/_NumberInput.tsx
@@ -84,6 +84,7 @@ export const NumberInput = ({
           suffix || (
             <StyledActionWrapper>
               <StyledButtonAction
+                type="button"
                 onClick={() => {
                   inputRef.current?.stepUp();
                   inputRef.current?.dispatchEvent(
@@ -94,6 +95,7 @@ export const NumberInput = ({
                 <ChevronUpIcon size={16} />
               </StyledButtonAction>
               <StyledButtonAction
+                type="button"
                 onClick={() => {
                   inputRef.current?.stepDown();
                   inputRef.current?.dispatchEvent(

--- a/src/components/input/input-type/_PasswordInput.tsx
+++ b/src/components/input/input-type/_PasswordInput.tsx
@@ -73,6 +73,7 @@ export const PasswordInput = ({
         suffix={
           suffix || (
             <StyledButtonAction
+              type="button"
               onClick={() =>
                 setInputType(inputType === 'password' ? 'text' : 'password')
               }

--- a/src/components/input/input-type/_TimeInput.tsx
+++ b/src/components/input/input-type/_TimeInput.tsx
@@ -93,6 +93,7 @@ export const TimeInput = ({
           suffix || (
             <StyledActionWrapper>
               <StyledButtonAction
+                type="button"
                 onClick={() => {
                   inputRef.current?.showPicker();
                   inputRef.current?.dispatchEvent(

--- a/src/components/layout/__stories__/UserMenu.tsx
+++ b/src/components/layout/__stories__/UserMenu.tsx
@@ -120,7 +120,11 @@ export const UserMenu = ({ addSpacing = true }: Props) => {
 
   return (
     <MenuWrapper addSpacing={addSpacing}>
-      <UserInfo addSpacing={addSpacing} onClick={() => setOpen(!open)}>
+      <UserInfo
+        type="button"
+        addSpacing={addSpacing}
+        onClick={() => setOpen(!open)}
+      >
         <Avatar />
         <StyledVStack spacing="none">
           <strong>Hello</strong>

--- a/src/components/rich-checkbox/RichCheckbox.tsx
+++ b/src/components/rich-checkbox/RichCheckbox.tsx
@@ -91,6 +91,7 @@ export const RichCheckbox = ({ onClick, items }: RichCheckboxProps) => (
       const { checked, icon, label, subtitle, value } = item;
       return (
         <StyledRichCheckbox
+          type="button"
           data-state={checked ? 'checked' : ''}
           value={value}
           key={value}

--- a/src/components/rich-radio/RichRadio.tsx
+++ b/src/components/rich-radio/RichRadio.tsx
@@ -132,6 +132,7 @@ export const RichRadio = <T extends string>({
     <StyledRadioGroup spacing="space-half" className={className}>
       {items.map(item => (
         <StyledItem
+          type="button"
           key={item.value}
           data-tip={item.tooltip}
           data-disabled={item.disabled}

--- a/src/components/tag/Tag.tsx
+++ b/src/components/tag/Tag.tsx
@@ -48,7 +48,7 @@ export const Tag = ({
   onClose,
 }: TagProps) => (
   <TagWrapper className={className}>
-    <StyledTag iconRight={iconRight} onClick={onClose}>
+    <StyledTag type="button" iconRight={iconRight} onClick={onClose}>
       {icon}
       <p>{children}</p>
       <RemoveIcon size={16} />


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

I noticed in account-web that clicking the hide password eye icon causes the submit event to fire, which is because default button type is `submit`.

This PR adds `type="button"` to all our buttons so this does not happen.

## Todo

- [ ] Bump version and add tag
