### PR TITLE
refactor: remove layout effect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.23",
+  "version": "3.4.24",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useLayoutEffect, useRef, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -47,7 +47,7 @@ export const Collapse = ({
 
   const contentWrapperRef = useRef<HTMLDivElement>(null);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const resizeObserver = new ResizeObserver(entries => {
       setContentHeight(entries[0]?.contentRect.height);
     });
@@ -61,7 +61,7 @@ export const Collapse = ({
     };
   }, []);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     setHideOverflow(true);
     if (!collapsed) {
       setCompletelyCollapsed(false);


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR removes the `useLayoutEffect` from Collapse. It originally was needed with the old design, but now it looks like it isn't needed anymore. It was breaking the SSR, so this ends up working out nicely.

## Todo

- [x] Bump version and add tag
