### PR TITLE
Fix/table row collapse and dividers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.25",
+  "version": "3.4.26",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -9,6 +9,12 @@ const StyledCard = styled.div`
   border: ${theme.border};
   border-radius: ${theme.radius6};
   padding: ${theme.space24};
+
+  /** Dividers should stretch the whole width by default */
+  hr {
+    margin-left: ${theme.spaceNegative24};
+    margin-right: ${theme.spaceNegative24};
+  }
 `;
 
 const CardHeader = styled.header`

--- a/src/components/divider/Divider.tsx
+++ b/src/components/divider/Divider.tsx
@@ -1,26 +1,39 @@
 import { theme } from 'src/styles/constants/theme';
 import styled from 'styled-components';
 
-const DividerHorizontal = styled.hr`
-  margin: ${theme.space24} 0;
+type StyledProps = {
+  outset: boolean;
+};
+
+const DividerHorizontal = styled.hr<StyledProps>`
+  margin: ${theme.space24} ${p => (p.outset ? theme.spaceNegative24 : 0)};
   border-color: ${theme.borderColor};
 `;
 
-const DividerVertical = styled.hr`
-  margin: 0 ${theme.space24};
+const DividerVertical = styled.hr<StyledProps>`
+  margin: ${p => (p.outset ? theme.spaceNegative24 : 0)} ${theme.space24};
   height: auto;
   align-self: stretch;
   border-right: solid thin ${theme.borderColor};
 `;
 
 type Props = {
-  vertical?: boolean;
   className?: string;
+  vertical?: boolean;
+  /**
+   * Adds negative margin (-24px) in the non-primary direction. For use with Cards and other containers with padding.
+   * @default false
+   */
+  outset?: boolean;
 };
 
-export const Divider = ({ className, vertical = false }: Props) =>
+export const Divider = ({
+  className,
+  vertical = false,
+  outset = false,
+}: Props) =>
   vertical ? (
-    <DividerVertical className={className} />
+    <DividerVertical className={className} outset={outset} />
   ) : (
-    <DividerHorizontal className={className} />
+    <DividerHorizontal className={className} outset={outset} />
   );

--- a/src/components/divider/Divider.tsx
+++ b/src/components/divider/Divider.tsx
@@ -2,12 +2,12 @@ import { theme } from 'src/styles/constants/theme';
 import styled from 'styled-components';
 
 const DividerHorizontal = styled.hr`
-  margin: ${theme.space4} 0;
+  margin: ${theme.space24} 0;
   border-color: ${theme.borderColor};
 `;
 
 const DividerVertical = styled.hr`
-  margin: 0 ${theme.space4};
+  margin: 0 ${theme.space24};
   height: auto;
   align-self: stretch;
   border-right: solid thin ${theme.borderColor};

--- a/src/components/divider/Divider.tsx
+++ b/src/components/divider/Divider.tsx
@@ -1,17 +1,13 @@
 import { theme } from 'src/styles/constants/theme';
 import styled from 'styled-components';
 
-type StyledProps = {
-  outset: boolean;
-};
-
-const DividerHorizontal = styled.hr<StyledProps>`
-  margin: ${theme.space24} ${p => (p.outset ? theme.spaceNegative24 : 0)};
+const DividerHorizontal = styled.hr`
+  margin: ${theme.space24} 0;
   border-color: ${theme.borderColor};
 `;
 
-const DividerVertical = styled.hr<StyledProps>`
-  margin: ${p => (p.outset ? theme.spaceNegative24 : 0)} ${theme.space24};
+const DividerVertical = styled.hr`
+  margin: 0 ${theme.space24};
   height: auto;
   align-self: stretch;
   border-right: solid thin ${theme.borderColor};
@@ -20,20 +16,11 @@ const DividerVertical = styled.hr<StyledProps>`
 type Props = {
   className?: string;
   vertical?: boolean;
-  /**
-   * Adds negative margin (-24px) in the non-primary direction. For use with Cards and other containers with padding.
-   * @default false
-   */
-  outset?: boolean;
 };
 
-export const Divider = ({
-  className,
-  vertical = false,
-  outset = false,
-}: Props) =>
+export const Divider = ({ className, vertical = false }: Props) =>
   vertical ? (
-    <DividerVertical className={className} outset={outset} />
+    <DividerVertical className={className} />
   ) : (
-    <DividerHorizontal className={className} outset={outset} />
+    <DividerHorizontal className={className} />
   );

--- a/src/components/divider/__stories__/Divider.stories.tsx
+++ b/src/components/divider/__stories__/Divider.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta } from '@storybook/react/types-6-0';
+import { Card } from 'src/components/card/Card';
 import { Text } from 'src/components/text/Text';
 import { ArrowDownIcon } from 'src/icons/ArrowDownIcon';
 import { ArrowLeftIcon } from 'src/icons/ArrowLeftIcon';
@@ -8,10 +9,10 @@ import { CircleIcon } from 'src/icons/CircleIcon';
 import { theme } from 'src/styles/constants/theme';
 import styled from 'styled-components';
 
-import { Divider as DividerComponent } from '../Divider';
+import { Divider } from '../Divider';
 
 const DividerMeta: Meta = {
-  component: DividerComponent,
+  component: Divider,
 };
 
 export default DividerMeta;
@@ -62,30 +63,30 @@ const Column = styled(ColumnInset)`
 
 // These dividers have custom styling to not appear inset when the container has the padding. There are multiple approaches to make it full size, as demonstrated here.
 
-const StyledDividerVertical = styled(DividerComponent)`
+const StyledDividerVertical = styled(Divider)`
   margin: ${theme.spaceNegative8} 0;
 `;
 
-const StyledDividerHorizontal = styled(DividerComponent)`
+const StyledDividerHorizontal = styled(Divider)`
   margin: 0 ${theme.spaceNegative8};
 `;
 
-export const Divider = () => (
+export const Basic = () => (
   <Wrapper>
     <Wrapper>
       <Text type="title">Vertical</Text>
       <Row>
         <ArrowLeftIcon />
-        <DividerComponent vertical />
+        <Divider vertical />
         <CircleIcon />
-        <DividerComponent vertical />
+        <Divider vertical />
         <ArrowRightIcon />
       </Row>
       <RowInset>
         <ArrowLeftIcon />
-        <DividerComponent vertical />
+        <Divider vertical />
         <CircleIcon />
-        <DividerComponent vertical />
+        <Divider vertical />
         <ArrowRightIcon />
       </RowInset>
       <RowInset>
@@ -100,16 +101,16 @@ export const Divider = () => (
     <ColumnWrapper>
       <Column>
         <ArrowUpIcon />
-        <DividerComponent />
+        <Divider />
         <CircleIcon />
-        <DividerComponent />
+        <Divider />
         <ArrowDownIcon />
       </Column>
       <ColumnInset>
         <ArrowUpIcon />
-        <DividerComponent />
+        <Divider />
         <CircleIcon />
-        <DividerComponent />
+        <Divider />
         <ArrowDownIcon />
       </ColumnInset>
       <ColumnInset>
@@ -121,4 +122,26 @@ export const Divider = () => (
       </ColumnInset>
     </ColumnWrapper>
   </Wrapper>
+);
+
+export const InCard = () => (
+  <div>
+    <Card label="Default">
+      <div>Some stuff</div>
+
+      <Divider />
+
+      <div>Some other stuff</div>
+    </Card>
+
+    <Divider />
+
+    <Card label="Outset">
+      <div>Some stuff</div>
+
+      <Divider outset />
+
+      <div>Some other stuff</div>
+    </Card>
+  </div>
 );

--- a/src/components/divider/__stories__/Divider.stories.tsx
+++ b/src/components/divider/__stories__/Divider.stories.tsx
@@ -125,23 +125,13 @@ export const Basic = () => (
 );
 
 export const InCard = () => (
-  <div>
-    <Card label="Default">
-      <div>Some stuff</div>
-
-      <Divider />
-
-      <div>Some other stuff</div>
-    </Card>
+  <Card label="Default">
+    <div>
+      Cards automatically add negative margin to <code>{'<hr/>'}</code> tags
+    </div>
 
     <Divider />
 
-    <Card label="Outset">
-      <div>Some stuff</div>
-
-      <Divider outset />
-
-      <div>Some other stuff</div>
-    </Card>
-  </div>
+    <div>Some other stuff</div>
+  </Card>
 );

--- a/src/components/table/TableRowCollapse.tsx
+++ b/src/components/table/TableRowCollapse.tsx
@@ -16,6 +16,13 @@ type StyleProps = {
 
 const StyledTableRow = styled(TableRow)<StyleProps>`
   ${p =>
+    !p.collapsed &&
+    css`
+      td {
+        border-bottom: 0;
+      }
+    `}
+  ${p =>
     p.collapsible &&
     css`
       cursor: pointer;
@@ -26,7 +33,6 @@ const StyledTableRow = styled(TableRow)<StyleProps>`
 `;
 
 const CollapsibleCell = styled(TableCell)<{ collapsed: boolean }>`
-  font-size: ${p => (!p.collapsed ? 'inherit' : 0)};
   border-bottom: ${p => (!p.collapsed ? 'inherit' : 0)};
   && {
     height: ${p => (!p.collapsed ? 'inherit' : 0)};

--- a/src/components/table/TableRowCollapse.tsx
+++ b/src/components/table/TableRowCollapse.tsx
@@ -16,14 +16,6 @@ type StyleProps = {
 
 const StyledTableRow = styled(TableRow)<StyleProps>`
   ${p =>
-    !p.collapsed &&
-    css`
-      margin-bottom: 16px;
-      td {
-        border-bottom: 0;
-      }
-    `}
-  ${p =>
     p.collapsible &&
     css`
       cursor: pointer;


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR changes the default spacing on dividers to match what dashboard uses everywhere.

- fixes a tiny little jarring animation in the table row collapse that I noticed.

## Todo

- [x] Bump version and add tag
