### PR TITLE
refactor(slide): smoother when suddenly slide

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.27",
+  "version": "3.4.28",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.26",
+  "version": "3.4.27",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -1,5 +1,6 @@
 import { Range, Root, Thumb, Track } from '@radix-ui/react-slider';
 import { theme } from 'src/styles/constants/theme';
+import { StyledProps } from 'src/types';
 import styled from 'styled-components';
 
 const StyledSlider = styled(Root)`
@@ -11,30 +12,34 @@ const StyledSlider = styled(Root)`
   user-select: none;
 `;
 
-const StyledTrack = styled(Track)`
+const StyledTrack = styled(Track)<StyledProps<SliderProps>>`
   background-color: ${theme.gray200};
   border-radius: 20px;
   box-shadow: ${theme.v3ShadowInset};
   flex-grow: 1;
-  height: 12px;
+  height: ${p => p.$size && `${p.$size}px`};
   position: relative;
+  & + span {
+    transition: 0.3s all ease;
+  }
 `;
 
 const StyledRange = styled(Range)`
   background-color: ${theme.primary};
+  transition: 0.3s all ease;
   border-radius: 9999px;
   height: 100%;
   position: absolute;
 `;
 
-const StyledThumb = styled(Thumb)`
+const StyledThumb = styled(Thumb)<StyledProps<SliderProps>>`
   background: white;
   border-radius: 20px;
   border: ${theme.border};
   box-shadow: ${theme.v3ShadowBase};
   display: block;
-  height: 24px;
-  width: 24px;
+  height: ${p => p.$size && `${p.$size * 2}px`};
+  width: ${p => p.$size && `${p.$size * 2}px`};
 
   cursor: pointer;
 
@@ -47,9 +52,9 @@ const StyledThumb = styled(Thumb)`
   }
 `;
 
-const SliderWrapper = styled.div`
+const SliderWrapper = styled.div<StyledProps<{ hideIndicator: boolean }>>`
   position: relative;
-  height: calc(56px + ${theme.space24} + 10px);
+  height: ${p => !p.$hideIndicator && `calc(56px + ${theme.space24} + 10px)`};
 `;
 
 const Indicator = styled.div`
@@ -88,11 +93,17 @@ const IndicatorWrapper = styled.div`
 `;
 
 export type SliderProps = {
+  className?: string;
   hideIndicator?: boolean;
   max?: number;
   min?: number;
   onChange: (newValue: number) => void;
   step?: number;
+  /**
+   * How thick you want the progress look
+   * @default 12
+   * */
+  size?: 8 | 12;
   /**
    * @default "%"
    */
@@ -105,11 +116,13 @@ export const Slider = ({
   max,
   min,
   onChange,
+  className,
   step,
+  size = 12,
   suffix = '%',
   value,
 }: SliderProps) => (
-  <SliderWrapper>
+  <SliderWrapper className={className} $hideIndicator={hideIndicator}>
     <StyledSlider
       max={max}
       min={min}
@@ -117,11 +130,11 @@ export const Slider = ({
       step={step}
       value={[value]}
     >
-      <StyledTrack>
+      <StyledTrack $size={size}>
         <StyledRange />
       </StyledTrack>
 
-      <StyledThumb>
+      <StyledThumb $size={size}>
         {!hideIndicator && (
           <IndicatorWrapper>
             <UpTriangle />

--- a/src/components/slider/__stories__/Slider.stories.tsx
+++ b/src/components/slider/__stories__/Slider.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Meta, Story } from '@storybook/react/types-6-0';
 import {
@@ -18,24 +18,47 @@ const Template: Story<SliderProps> = ({
   min,
   step,
   value: _value,
+  size,
 }: SliderProps) => {
   const [value, setValue] = useState(_value);
-
+  const [randomValue, setRandomValue] = useState(_value);
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRandomValue(Math.round(Math.random() * 100));
+    }, 2000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
   return (
     <VStack>
       <SliderComponent
         max={max}
         min={min}
         onChange={n => setValue(n)}
+        size={size}
         step={step}
         value={value}
       />
+      <div>
+        Random value: {randomValue}
+        <SliderComponent
+          max={max}
+          min={min}
+          hideIndicator
+          size={size}
+          onChange={n => setRandomValue(n)}
+          step={step}
+          value={randomValue}
+        />
+      </div>
       <div>
         No indicator (Separate value): value: {value}
         <SliderComponent
           max={max}
           min={min}
           hideIndicator
+          size={size}
           onChange={n => setValue(n)}
           step={step}
           value={value}
@@ -47,6 +70,7 @@ const Template: Story<SliderProps> = ({
           max={max}
           min={min}
           suffix="$"
+          size={size}
           onChange={n => setValue(n)}
           step={step}
           value={value}


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
Preview url: [link](https://amino-mp0d7lg6y-zonos.vercel.app/?path=/story/amino-slider--slider)
This PR:
- remove fixed height when hiding indicator
- add size props for the thickness of the bar
- make it transition smoother when the value is set directly

<img width="1258" alt="image" src="https://user-images.githubusercontent.com/17950626/221295899-972ded04-536d-49b2-883e-1146dca7f914.png">
## Todo

- [ ] Bump version and add tag
