### PR TITLE
Refactor/coversheet actions improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.29",
+  "version": "3.4.28",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.28",
+  "version": "3.4.29",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.27",
+  "version": "3.4.28",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/cover-sheet/CoverSheet.tsx
+++ b/src/components/cover-sheet/CoverSheet.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
 import { AnimatePresence, motion } from 'framer-motion';
@@ -63,6 +63,8 @@ export type CoverSheetProps = {
   open: boolean;
   label: string;
   onClose: () => void;
+  /** used for setting id of the wrapper of where the action will be located */
+  actionWrapperId?: string;
   actions?: ReactNode;
 };
 
@@ -72,8 +74,21 @@ export const CoverSheet = ({
   label,
   onClose,
   children,
+  actionWrapperId = '__cover-sheet-actions',
   actions,
 }: CoverSheetProps) => {
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    if (document.querySelectorAll(`[id='${actionWrapperId}']`).length > 0) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Duplicate id "${actionWrapperId}" detected in "CoverSheet" component. Please set "actionWrapperId" to an unique id.`
+      );
+    }
+  }, [actionWrapperId]);
+
   if (typeof document !== 'undefined') {
     const body = document.querySelector('body');
     if (body) {
@@ -93,8 +108,12 @@ export const CoverSheet = ({
                   onClick={onClose}
                 />
                 <StyledHeader type="header">{label}</StyledHeader>
-                <div id="cover-sheet-actions">
-                  {actions && <CoverSheetActions>{actions}</CoverSheetActions>}
+                <div id={actionWrapperId}>
+                  {actions && (
+                    <CoverSheetActions coverSheetActionId={actionWrapperId}>
+                      {actions}
+                    </CoverSheetActions>
+                  )}
                 </div>
               </Header>
               <Content>{children}</Content>

--- a/src/components/cover-sheet/CoverSheetActions.tsx
+++ b/src/components/cover-sheet/CoverSheetActions.tsx
@@ -11,7 +11,10 @@ const Actions = styled.div`
 export type CoverSheetProps = {
   children: ReactNode;
   className?: string;
-  /** default id for coversheet component is `__cover-sheet-actions` */
+  /**
+   * Determine where to put this actions in the coversheet
+   * @default id for coversheet component is `__cover-sheet-actions`
+   * */
   coverSheetActionId: string;
 };
 

--- a/src/components/cover-sheet/CoverSheetActions.tsx
+++ b/src/components/cover-sheet/CoverSheetActions.tsx
@@ -9,11 +9,17 @@ const Actions = styled.div`
 `;
 
 export type CoverSheetProps = {
-  className?: string;
   children: ReactNode;
+  className?: string;
+  /** default id for coversheet component is `__cover-sheet-actions` */
+  coverSheetActionId: string;
 };
 
-export const CoverSheetActions = ({ className, children }: CoverSheetProps) => {
+export const CoverSheetActions = ({
+  children,
+  className,
+  coverSheetActionId,
+}: CoverSheetProps) => {
   const [coverSheetReady, setCoverSheetReady] = useState(false);
 
   useEffect(() => {
@@ -23,7 +29,7 @@ export const CoverSheetActions = ({ className, children }: CoverSheetProps) => {
   }, [coverSheetReady]);
 
   if (typeof document !== 'undefined' && coverSheetReady) {
-    const div = document.querySelector('#cover-sheet-actions');
+    const div = document.querySelector(`#${coverSheetActionId}`);
     if (div) {
       return createPortal(
         <Actions className={className}>

--- a/src/components/cover-sheet/__stories__/CoverSheet.stories.tsx
+++ b/src/components/cover-sheet/__stories__/CoverSheet.stories.tsx
@@ -7,6 +7,7 @@ import {
   CoverSheetProps,
 } from 'src/components/cover-sheet/CoverSheet';
 import { CoverSheetActions } from 'src/components/cover-sheet/CoverSheetActions';
+import { VStack } from 'src/components/stack/VStack';
 import styled from 'styled-components';
 
 const CoverSheetMeta: Meta = {
@@ -27,25 +28,50 @@ const Template: Story<CoverSheetProps & { actionPortalOpen?: boolean }> = ({
   children,
   ...props
 }: CoverSheetProps & { actionPortalOpen?: boolean }) => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
   const [actionPortalOpen, setActionPortalOpen] = useState(_actionPortalOpen);
+  const [secondCoversheetOpen, setSecondCoversheetOpen] = useState(false);
+
   return (
     <CenteredDiv>
       <Button onClick={() => setOpen(true)}>Open</Button>
 
       <CoverSheet {...props} onClose={() => setOpen(false)} open={open}>
         {children}
-        <Button onClick={() => setActionPortalOpen(!actionPortalOpen)}>
-          Toggle coversheet action portal
-        </Button>
+        <VStack>
+          <Button onClick={() => setActionPortalOpen(!actionPortalOpen)}>
+            Toggle coversheet action portal
+          </Button>
+          <Button
+            intent="primary"
+            onClick={() => setSecondCoversheetOpen(!secondCoversheetOpen)}
+          >
+            Open second CoverSheet
+          </Button>
+        </VStack>
         {actionPortalOpen && (
-          <CoverSheetActions>
+          <CoverSheetActions coverSheetActionId="__cover-sheet-actions">
             <Button onClick={() => setActionPortalOpen(false)}>
               Remove coversheet actions
             </Button>
             <Button>Save (coversheet)</Button>
           </CoverSheetActions>
         )}
+      </CoverSheet>
+      <CoverSheet
+        open={secondCoversheetOpen}
+        label="Second Coversheet"
+        onClose={() => setSecondCoversheetOpen(false)}
+        actionWrapperId="second-cover-sheet"
+      >
+        This is a second coversheet set with <b>actionWrapperId</b>. The button
+        action <b>Action in second coversheete</b> should be possitioned
+        correctly at the top right of this coversheet
+        <CoverSheetActions coverSheetActionId="second-cover-sheet">
+          <Button onClick={() => setSecondCoversheetOpen(false)}>
+            Action in second coversheete
+          </Button>
+        </CoverSheetActions>
       </CoverSheet>
     </CenteredDiv>
   );
@@ -60,12 +86,12 @@ CoverSheetWithActions.args = {
     </>
   ),
   label: 'Label',
-  children: <div>Children</div>,
+  children: <div />,
 };
 
 export const CoverSheetNoActions = Template.bind({});
 CoverSheetNoActions.args = {
   actionPortalOpen: true,
   label: 'Label',
-  children: <div>Children</div>,
+  children: <div />,
 };

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -167,7 +167,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             ].join(' ')}
             disabled={disabled}
             ref={ref}
-            rows={rows || 4}
+            rows={rows}
             label={label}
             value={value}
             {...props}


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
Preview url: [amino-1tms2gw0c-zonos.vercel.app](https://amino-1tms2gw0c-zonos.vercel.app/?path=/story/amino-coversheet--cover-sheet-with-actions)
This PR adds the ability to add `id` to Coversheet actions wrapper in `CoverSheet` component. This would allow the `CoverSheetActions` component to attach to the right CoverSheet if there are multiple CoverSheets.
<img width="765" alt="image" src="https://user-images.githubusercontent.com/17950626/223243714-0820de3c-d2ae-417a-ac69-154d2cbb5ec5.png">


## Todo

- [ ] Bump version and add tag
