### PR TITLE
refactor: convert camelCase for acronyms

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -334,7 +334,7 @@ export type GroupTag = 'div' | 'a' | 'button';
 
 /* These types are kind of hacked because styled components makes it difficult to do polymorphic components. */
 
-type MyHTMLElement<T extends GroupTag> = T extends 'a'
+type MyHtmlElement<T extends GroupTag> = T extends 'a'
   ? HTMLAnchorElement
   : T extends 'div'
   ? HTMLDivElement
@@ -342,7 +342,7 @@ type MyHTMLElement<T extends GroupTag> = T extends 'a'
 
 export type ButtonProps<T extends GroupTag = 'button'> = ButtonBase &
   Omit<ComponentPropsWithoutRef<T>, keyof ButtonBase | 'onClick'> & {
-    onClick?: MouseEventHandler<MyHTMLElement<T>>;
+    onClick?: MouseEventHandler<MyHtmlElement<T>>;
     tag?: T;
   };
 

--- a/src/components/connection-map/__stories__/ConnectionMap.stories.tsx
+++ b/src/components/connection-map/__stories__/ConnectionMap.stories.tsx
@@ -7,7 +7,7 @@ import { HStack } from 'src/components/stack/HStack';
 import { VStack } from 'src/components/stack/VStack';
 import { IGeoJsonWorld } from 'src/types/IGeoJsonWorld';
 import styled from 'styled-components';
-import useSWR from 'swr';
+import useSwr from 'swr';
 
 import { getCountryUrls } from '../../select/__stories__/getCountryUrls.stories';
 import { useCountryOptions } from '../../select/__stories__/useCountryOptions.stories';
@@ -43,7 +43,7 @@ const ConnectionMapTemplate: Story<{ from: string; to: string }> = ({
   to: _to,
 }) => {
   const { dashboardUrl } = getCountryUrls();
-  const { data: worldData } = useSWR<IGeoJsonWorld>(GEO_URL, async params => {
+  const { data: worldData } = useSwr<IGeoJsonWorld>(GEO_URL, async params => {
     const response = await fetch(params);
     const json = await response.json();
     return json;


### PR DESCRIPTION
## Jira issue
[Avoid Uppercase Acronyms](https://myzonos.atlassian.net/browse/FE-15)

## Description

This PR converts some uppercase acronyms to camelCase.
Patterns: `SWRT`,  `HTML`, `SWR`, `QL`, `HTTP`, `HTTPS`, `AI`, `AST`, `API`, `JSON`.
This updated with Vscode:
**PS:** There would be some cases that are not what we want. You would need to filter and commit only the changes you want: 
VsCode search setting 
- Search input: `([a-z])(SWRT|HTML|SWR|QL|HTTP|HTTPS|AI|AST|API|JSON)`
- Replacement: `$1\u\L$2`
- Files to exclude: `*.json`
![image](https://user-images.githubusercontent.com/17950626/224171421-6e781b62-35f4-4b03-a293-4eca350d961f.png)
