### PR TITLE
Fix/colors and 0 spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.37",
+  "version": "3.4.38",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/badge/__stories__/Badge.stories.tsx
+++ b/src/components/badge/__stories__/Badge.stories.tsx
@@ -25,7 +25,7 @@ const BadgeMeta: Meta = {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A28',
+      url: 'https://www.figma.com/file/WnKnmG7L3Q74hqPsw4rbEE/Amino-2.0?node-id=357-7819&t=JAnOnPQZhj04fF3s-0',
     },
   },
 };

--- a/src/components/layout/NavigationGroup.tsx
+++ b/src/components/layout/NavigationGroup.tsx
@@ -22,7 +22,7 @@ const StyledNavigationItem = styled.div<StyledNavigationItemProps>`
   font-weight: 500;
   border-radius: ${theme.radius6};
   &:hover {
-    background-color: ${theme.gray100};
+    background-color: ${theme.gray50};
     color: black;
     svg {
       color: ${theme.gray700};

--- a/src/components/stack/HStack.tsx
+++ b/src/components/stack/HStack.tsx
@@ -1,11 +1,11 @@
 import { theme } from 'src/styles/constants/theme';
 import styled from 'styled-components';
 
+import { GridSpacing } from './GridSpacing';
 import { Stack, StackProps } from './Stack';
 
-const StyledHStack = styled(Stack)<StackProps>`
-  grid-column-gap: ${p =>
-    p.spacing ? theme[`space${p.spacing}`] : theme.space24};
+const StyledHStack = styled(Stack)<{ $spacing: GridSpacing }>`
+  grid-column-gap: ${p => theme[`space${p.$spacing}`]};
   grid-auto-flow: column;
 `;
 
@@ -15,6 +15,8 @@ const StyledHStack = styled(Stack)<StackProps>`
  * @param alignment - Optional alignment
  * @param spacing - Optional spacing between elements
  */
-export const HStack = ({ children, ...props }: StackProps) => (
-  <StyledHStack {...props}>{children}</StyledHStack>
+export const HStack = ({ children, spacing = 24, ...props }: StackProps) => (
+  <StyledHStack $spacing={spacing} {...props}>
+    {children}
+  </StyledHStack>
 );

--- a/src/components/stack/Stack.tsx
+++ b/src/components/stack/Stack.tsx
@@ -15,7 +15,9 @@ type DivProps = Omit<
 >;
 
 export interface StackProps extends DivProps {
+  /** @default 'unset' */
   alignment?: GridAlignment;
+  /** @default 24 */
   spacing?: GridSpacing;
   children: ReactNode;
 }
@@ -24,14 +26,16 @@ export interface StackProps extends DivProps {
  *
  * @param alignment - Optional alignment
  */
-const StyledStack = styled.div<StackProps>`
+const StyledStack = styled.div<{ $alignment?: GridAlignment }>`
   display: grid;
   grid-auto-columns: minmax(0, 1fr);
   & > * {
-    justify-self: ${p => p.alignment || 'unset'};
+    justify-self: ${p => p.$alignment || 'unset'};
   }
 `;
 
-export const Stack = ({ children, ...otherProps }: StackProps) => (
-  <StyledStack {...otherProps}>{children}</StyledStack>
+export const Stack = ({ children, alignment, ...otherProps }: StackProps) => (
+  <StyledStack $alignment={alignment} {...otherProps}>
+    {children}
+  </StyledStack>
 );

--- a/src/components/stack/VStack.tsx
+++ b/src/components/stack/VStack.tsx
@@ -1,11 +1,11 @@
 import { theme } from 'src/styles/constants/theme';
 import styled from 'styled-components';
 
+import { GridSpacing } from './GridSpacing';
 import { Stack, StackProps } from './Stack';
 
-const StyledVStack = styled(Stack)<StackProps>`
-  grid-row-gap: ${p =>
-    p.spacing ? theme[`space${p.spacing}`] : theme.space24};
+const StyledVStack = styled(Stack)<{ $spacing: GridSpacing }>`
+  grid-row-gap: ${p => theme[`space${p.$spacing}`]};
   grid-auto-flow: row;
 `;
 
@@ -15,6 +15,8 @@ const StyledVStack = styled(Stack)<StackProps>`
  * @param alignment - Optional alignment
  * @param spacing - Optional spacing between elements
  */
-export const VStack = ({ children, ...props }: StackProps) => (
-  <StyledVStack {...props}>{children}</StyledVStack>
+export const VStack = ({ children, spacing = 24, ...props }: StackProps) => (
+  <StyledVStack $spacing={spacing} {...props}>
+    {children}
+  </StyledVStack>
 );

--- a/src/components/table/TableRowCollapse.tsx
+++ b/src/components/table/TableRowCollapse.tsx
@@ -27,7 +27,7 @@ const StyledTableRow = styled(TableRow)<StyleProps>`
     css`
       cursor: pointer;
       :hover {
-        background: ${theme.gray100};
+        background: ${theme.gray50};
       }
     `}
 `;


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes an issue with `0` spacing logic being falsy from before. It also uses `gray50` in applicable places now that it isn't deprecated.

## Todo

- [ ] Bump version and add tag
