### PR TITLE
Fix: text button ripple, currency formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.38",
+  "version": "3.4.39",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -317,6 +317,7 @@ type ButtonBase = {
   disabled?: boolean;
   icon?: ReactNode;
   iconRight?: boolean;
+  /** @default 'secondary' */
   intent?: IntentProps;
   /** @default false */
   loading?: boolean;
@@ -356,7 +357,7 @@ export function Button<T extends GroupTag = 'button'>({
   disabled = false,
   icon,
   iconRight,
-  intent,
+  intent = 'secondary',
   loading = false,
   loadingText,
   noRipple = false,
@@ -397,7 +398,7 @@ export function Button<T extends GroupTag = 'button'>({
 
   const { rippleEnabled, getRippleHandlers } = useRipple({
     rippleRef,
-    rippleEnabled: !noRipple && intent !== 'plain',
+    rippleEnabled: !noRipple && !['plain', 'text'].includes(intent),
     disabled: disabled || loading,
   });
 
@@ -454,7 +455,6 @@ export function Button<T extends GroupTag = 'button'>({
       return (
         <TextButton as={tag} {...buttonProps}>
           {renderContent(spinnerColor)}
-          {rippleEnabled && <RippleGroup ref={rippleRef} />}
         </TextButton>
       );
     case 'link':

--- a/src/components/connection-map/ConnectionMap.tsx
+++ b/src/components/connection-map/ConnectionMap.tsx
@@ -19,10 +19,21 @@ import { Skeleton } from '../skeleton/Skeleton';
 
 const Map = styled.div`
   background: ${theme.gray100};
+  border-radius: ${theme.radius12};
+  overflow: hidden;
 
   * {
     outline: none;
   }
+`;
+
+const MapSkeleton = styled(Skeleton)`
+  box-sizing: border-box;
+  border-radius: ${theme.radius12};
+  width: 100%;
+  /* 50% padding is 100% of width, ratio is 33%, so half */
+  padding: 16.5%;
+  margin: 0;
 `;
 
 const getScale = (xDistance: number, yDistance: number) => {
@@ -80,7 +91,7 @@ export const ConnectionMap = ({
     [countries, geographies]
   );
 
-  const loading = !geographies || !countries.length;
+  const loading = !geographies || !countries.length || !from || !to;
 
   useEffect(() => {
     if (loading) {
@@ -129,7 +140,7 @@ export const ConnectionMap = ({
   }, [coordsForIso, to, from, loading]);
 
   if (loading) {
-    return <Skeleton height={height} />;
+    return <MapSkeleton height={height} />;
   }
 
   return (

--- a/src/components/connection-map/__stories__/ConnectionMap.stories.tsx
+++ b/src/components/connection-map/__stories__/ConnectionMap.stories.tsx
@@ -146,3 +146,6 @@ RussiaToEcuador.args = {
   from: 'RU',
   to: 'EC',
 };
+
+export const Loading = ConnectionMapTemplate.bind({});
+Loading.args = {};

--- a/src/components/currency/Currency.tsx
+++ b/src/components/currency/Currency.tsx
@@ -18,9 +18,14 @@ type Props = {
 };
 
 export const Currency = ({ amount, className, code }: Props) => {
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options
   const formattedCurrency = new Intl.NumberFormat(`en-US`, {
+    style: 'currency',
     currency: code,
-  }).format(amount);
+  })
+    .format(amount)
+    // Remove currency symbols because that's how we want to show it. There is no option to do this when usinge `style: 'currency'`
+    .replace(/[^0-9.-]+/g, '');
 
   const isNegative = amount < 0;
 


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR changes:

- text button type doesn't have a ripple anymore (noticed in dashboard back button)
- currencies use number formatting currency style to get better i18n (wanted 2 significant digits always, and found a better option)
- connection map loading state is better

## Todo

- [ ] Bump version and add tag
