### PR TITLE
refactor(CoverSheet): show error when id not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.40",
+  "version": "3.4.41",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/cover-sheet/CoverSheet.tsx
+++ b/src/components/cover-sheet/CoverSheet.tsx
@@ -81,7 +81,7 @@ export const CoverSheet = ({
     if (typeof document === 'undefined') {
       return;
     }
-    if (document.querySelectorAll(`[id='${actionWrapperId}']`).length > 0) {
+    if (document.querySelectorAll(`[id='${actionWrapperId}']`).length > 1) {
       // eslint-disable-next-line no-console
       console.error(
         `Duplicate id "${actionWrapperId}" detected in "CoverSheet" component. Please set "actionWrapperId" to an unique id.`

--- a/src/components/cover-sheet/CoverSheetActions.tsx
+++ b/src/components/cover-sheet/CoverSheetActions.tsx
@@ -41,9 +41,8 @@ export const CoverSheetActions = ({
         div
       );
     }
-    // eslint-disable-next-line no-console
-    console.error(
-      `CoverSheetActions: Could not find Coversheet wrapper with id ${coverSheetActionId}`
+    throw Error(
+      `CoverSheetActions: Could not find Coversheet wrapper with id "${coverSheetActionId}"`
     );
   }
   return null;

--- a/src/components/cover-sheet/CoverSheetActions.tsx
+++ b/src/components/cover-sheet/CoverSheetActions.tsx
@@ -41,6 +41,10 @@ export const CoverSheetActions = ({
         div
       );
     }
+    // eslint-disable-next-line no-console
+    console.error(
+      `CoverSheetActions: Could not find Coversheet wrapper with id ${coverSheetActionId}`
+    );
   }
   return null;
 };

--- a/src/components/cover-sheet/__stories__/CoverSheet.stories.tsx
+++ b/src/components/cover-sheet/__stories__/CoverSheet.stories.tsx
@@ -31,6 +31,8 @@ const Template: Story<CoverSheetProps & { actionPortalOpen?: boolean }> = ({
   const [open, setOpen] = useState(true);
   const [actionPortalOpen, setActionPortalOpen] = useState(_actionPortalOpen);
   const [secondCoversheetOpen, setSecondCoversheetOpen] = useState(false);
+  const [toggleErrorCoversheetAction, setToggleErrorCoversheetAction] =
+    useState(false);
 
   return (
     <CenteredDiv>
@@ -48,6 +50,9 @@ const Template: Story<CoverSheetProps & { actionPortalOpen?: boolean }> = ({
           >
             Open second CoverSheet
           </Button>
+          <Button onClick={() => setToggleErrorCoversheetAction(true)}>
+            Toggle error coversheet action (This will throw an error)
+          </Button>
         </VStack>
         {actionPortalOpen && (
           <CoverSheetActions coverSheetActionId="__cover-sheet-actions">
@@ -55,6 +60,13 @@ const Template: Story<CoverSheetProps & { actionPortalOpen?: boolean }> = ({
               Remove coversheet actions
             </Button>
             <Button>Save (coversheet)</Button>
+          </CoverSheetActions>
+        )}
+        {toggleErrorCoversheetAction && (
+          <CoverSheetActions coverSheetActionId="non-existing-id">
+            <Button onClick={() => setToggleErrorCoversheetAction(false)}>
+              Remove coversheet actions
+            </Button>
           </CoverSheetActions>
         )}
       </CoverSheet>


### PR DESCRIPTION
## Issue

<!-- [Jira issue description](url) -->
<!-- Example:
[3106 - Loup Charmant - Need dashboard switched from Hello](https://myzonos.atlassian.net/browse/DM-550)
-->
- CoverSheetAction is set to attach to an id of a `CoverSheet` wrapper that doesn't exist, so in case of the `Create Label` in the `Create Label flow` in the dashboard disappears, and it's hard to narrow down why as nothing in the dev tool console.

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR shows the errors in the console when couldn't find the id to attach to in the whole Dom

## Todo

- [ ] Bump version and add tag
