### PR TITLE
Style/rich radio and table row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.41",
+  "version": "3.4.42",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/rich-radio/RichRadio.tsx
+++ b/src/components/rich-radio/RichRadio.tsx
@@ -6,6 +6,8 @@ import { CheckmarkIcon } from 'src/icons/CheckmarkIcon';
 import { theme } from 'src/styles/constants/theme';
 import styled from 'styled-components';
 
+import { Text } from '../text/Text';
+
 const StyledIcon = styled.div`
   position: absolute;
   content: ' ';
@@ -29,7 +31,7 @@ const StyledActiveIcon = styled.div`
   justify-content: center;
 `;
 
-const StyledItem = styled.button`
+const StyledItem = styled.button<{ $itemHeight: number }>`
   position: relative;
   appearance: none;
   background: white;
@@ -42,7 +44,7 @@ const StyledItem = styled.button`
   display: flex;
   flex-direction: row;
   align-items: center;
-  height: 64px;
+  height: ${({ $itemHeight }) => $itemHeight}px;
   &:hover {
     background: ${theme.gray100};
     border: 1px solid ${theme.gray200};
@@ -53,7 +55,7 @@ const StyledItem = styled.button`
 
   &:focus {
     outline: none;
-    border: 1px solid ${theme.blue300};
+    border: 1px solid ${theme.blue400};
   }
   > div {
     display: flex;
@@ -62,9 +64,7 @@ const StyledItem = styled.button`
   }
 `;
 
-const Subtitle = styled.span`
-  opacity: 0.5;
-`;
+const Subtitle = styled(Text)``;
 
 const Label = styled.span`
   font-weight: 500;
@@ -73,8 +73,11 @@ const Label = styled.span`
 const StyledRadioGroup = styled(VStack)`
   ${StyledItem}[data-state='checked'] {
     background: ${theme.blue100};
-    border: 1px solid ${theme.blue300};
-    color: ${theme.blue600};
+    border: 2px solid ${theme.blue400};
+    color: ${theme.blue700};
+    ${Subtitle} {
+      color: ${theme.blue600};
+    }
   }
   svg {
     color: white;
@@ -90,32 +93,37 @@ const StyledTooltip = styled(ReactTooltip)`
 `;
 
 export type RichRadioItemType<T extends string> = {
+  disabled?: boolean;
   label: ReactNode;
   subtitle?: string;
-  value: T;
-  disabled?: boolean;
   tooltip?: string;
   tooltipSetting?: Omit<TooltipProps, 'title' | 'children'>;
+  value: T;
 };
 
 export type RichRadioProps<T extends string = string> = {
-  onChange: (value: T) => void;
-  renderCustomText?: (option: RichRadioItemType<T>) => ReactNode;
-  items: RichRadioItemType<T>[];
-  value: T | null;
+  activeIcon?: ReactNode;
   className?: string;
   icon?: ReactNode;
-  activeIcon?: ReactNode;
+  /**
+   * @default 40
+   */
+  itemHeight?: 40 | 64;
+  items: RichRadioItemType<T>[];
+  onChange: (value: T) => void;
+  renderCustomText?: (option: RichRadioItemType<T>) => ReactNode;
+  value: T | null;
 };
 
 export const RichRadio = <T extends string>({
+  activeIcon,
+  className,
+  icon,
+  itemHeight = 64,
+  items,
   onChange,
   renderCustomText,
-  items,
   value,
-  icon,
-  className,
-  activeIcon,
 }: RichRadioProps<T>) => {
   const [selectedValue, setSelectedValue] = useState(value);
 
@@ -133,6 +141,7 @@ export const RichRadio = <T extends string>({
       {items.map(item => (
         <StyledItem
           type="button"
+          $itemHeight={itemHeight}
           key={item.value}
           data-tip={item.tooltip}
           data-disabled={item.disabled}
@@ -153,7 +162,11 @@ export const RichRadio = <T extends string>({
           ) : (
             <div>
               <Label>{item.label}</Label>
-              {item.subtitle && <Subtitle>{item.subtitle}</Subtitle>}
+              {item.subtitle && (
+                <Subtitle color="gray900" type="body">
+                  {item.subtitle}
+                </Subtitle>
+              )}
             </div>
           )}
           {!!icon && <StyledIcon>{icon || <CheckmarkIcon />}</StyledIcon>}

--- a/src/components/rich-radio/RichRadio.tsx
+++ b/src/components/rich-radio/RichRadio.tsx
@@ -106,6 +106,7 @@ export type RichRadioProps<T extends string = string> = {
   className?: string;
   icon?: ReactNode;
   /**
+   * @param itemHeight
    * @default 40
    */
   itemHeight?: 40 | 64;

--- a/src/components/rich-radio/__stories__/RichRadio.stories.tsx
+++ b/src/components/rich-radio/__stories__/RichRadio.stories.tsx
@@ -25,17 +25,24 @@ const RichRadioMeta: Meta = {
       },
     },
   },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/WnKnmG7L3Q74hqPsw4rbEE/Amino-2.0?node-id=96%3A2004&t=TdkLVg0lxI1YWk86-4',
+    },
+  },
 };
 
 export default RichRadioMeta;
 
 const Template: Story<RichRadioProps> = ({
-  onChange,
+  activeIcon,
+  icon,
+  itemHeight,
   items,
+  onChange,
   renderCustomText,
   value,
-  icon,
-  activeIcon,
 }: RichRadioProps) => {
   const [radioValue, setRadioValue] = useState<string | null>(null);
 
@@ -51,6 +58,7 @@ const Template: Story<RichRadioProps> = ({
       renderCustomText={renderCustomText}
       items={items}
       icon={icon}
+      itemHeight={itemHeight}
       activeIcon={activeIcon}
     />
   );
@@ -91,12 +99,6 @@ BasicRichRadio.args = {
     },
   ],
   value: 'item1',
-};
-BasicRichRadio.parameters = {
-  design: {
-    type: 'figma',
-    url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=245%3A181',
-  },
 };
 
 export const CustomRichRadioOption = Template.bind({});
@@ -144,9 +146,35 @@ CustomRichRadioOption.args = {
     },
   ],
 };
-CustomRichRadioOption.parameters = {
-  design: {
-    type: 'figma',
-    url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=245%3A181',
-  },
+
+export const SmallRichRadio = Template.bind({});
+SmallRichRadio.args = {
+  itemHeight: 40,
+  items: [
+    {
+      label: 'Handbags, whether or not with shoulder strap',
+      value: 'item1',
+      tooltip: 'Handbags, whether or not with shoulder strap',
+      tooltipSetting: {
+        delayShow: 400,
+      },
+    },
+    {
+      label: 'Item 2',
+      value: 'item2',
+      tooltip:
+        'Handbags, whether or not with shoulder strap, including those without handle: With outer surface of sheeting of plastics or of textile materials',
+      tooltipSetting: {
+        delayShow: 400,
+      },
+    },
+    {
+      label: 'Item 3',
+      value: 'item3',
+    },
+    {
+      label: 'Item 4',
+      value: 'item4',
+    },
+  ],
 };

--- a/src/components/table/TableRow.tsx
+++ b/src/components/table/TableRow.tsx
@@ -4,8 +4,8 @@ import { theme } from 'src/styles/constants/theme';
 import styled from 'styled-components';
 
 const StyledTableRow = styled.tr`
-  :hover {
-    background-color: ${theme.gray100};
+  :not(.no-hover):hover {
+    background-color: ${theme.gray50};
   }
   th {
     color: ${theme.gray800};
@@ -16,7 +16,7 @@ const StyledTableRow = styled.tr`
   }
   /** Only affect on tr inside tbody */
   tbody &.active {
-    background: ${theme.gray100};
+    background: ${theme.gray50};
   }
 `;
 
@@ -24,6 +24,7 @@ export type TableRowProps = {
   active?: boolean;
   children: ReactNode;
   className?: string;
+  noHover?: boolean;
   onClick?: MouseEventHandler<HTMLTableRowElement>;
 };
 
@@ -31,11 +32,16 @@ export function TableRow({
   active,
   children,
   className,
+  noHover,
   onClick,
 }: TableRowProps) {
   return (
     <StyledTableRow
-      className={[className || '', active ? 'active' : ''].join(' ')}
+      className={[
+        className || '',
+        active ? 'active' : '',
+        noHover ? 'no-hover' : '',
+      ].join(' ')}
       onClick={onClick}
     >
       {children}


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR:
- adds no hover state for table row (will not change the background when hovering)
- adds small size RichRadio of each item and stories as new design of quotes page has it.

<img width="394" alt="image" src="https://user-images.githubusercontent.com/17950626/230221489-be4ab02e-f744-49c2-84e9-2eea06af3b21.png">
<img width="763" alt="image" src="https://user-images.githubusercontent.com/17950626/230221412-1cfa1ba0-96f7-4169-8bd9-7c996e0695bc.png">


## Todo

- [ ] Bump version and add tag
