### PR TITLE
Refactor/remove hover on non collapsible table row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.44",
+  "version": "3.4.45",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/rich-radio/RichRadio.tsx
+++ b/src/components/rich-radio/RichRadio.tsx
@@ -56,6 +56,7 @@ const StyledItem = styled.button<{ $itemHeight: number }>`
   &:focus {
     outline: none;
     border: 1px solid ${theme.blue400};
+    box-shadow: 0 0 0 1px ${theme.blue400};
   }
   > div {
     display: flex;
@@ -73,7 +74,8 @@ const Label = styled.span`
 const StyledRadioGroup = styled(VStack)`
   ${StyledItem}[data-state='checked'] {
     background: ${theme.blue100};
-    border: 2px solid ${theme.blue400};
+    border: 1px solid ${theme.blue400};
+    box-shadow: 0 0 0 1px ${theme.blue400};
     color: ${theme.blue700};
     ${Subtitle} {
       color: ${theme.blue600};

--- a/src/components/table/TableRowCollapse.tsx
+++ b/src/components/table/TableRowCollapse.tsx
@@ -26,9 +26,6 @@ const StyledTableRow = styled(TableRow)<StyleProps>`
     p.collapsible &&
     css`
       cursor: pointer;
-      :hover {
-        background: ${theme.gray50};
-      }
     `}
 `;
 
@@ -75,6 +72,7 @@ export const TableRowCollapse = ({
     <>
       <StyledTableRow
         collapsible={collapsible}
+        noHover={!collapsible}
         collapsed={collapsed}
         onClick={e => collapsible && onToggleCollapse(e)}
         className={className}
@@ -90,7 +88,7 @@ export const TableRowCollapse = ({
         </TableCell>
       </StyledTableRow>
       {collapsible && (
-        <TableRow>
+        <TableRow noHover>
           <CollapsibleCell colSpan={100} collapsed={collapsed}>
             <Collapse collapsed={collapsed}>{children}</Collapse>
           </CollapsibleCell>


### PR DESCRIPTION
## Jira issue

<!-- [Jira issue description](url) -->
<!-- Example:
[3106 - Loup Charmant - Need dashboard switched from Hello](https://myzonos.atlassian.net/browse/DM-550)
-->
- RichRadio issue: Jiggling issue as 1px is off when changing selected state between RichRadio items
- Has hover state on every TableRowCollapsible component

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR:
- adds 1px glow to not affecting the width and height of the `RichRadio` item when switching radio selection
- only have hover state on table row if it's collapsible (and not having hover state on the expand item)

## Todo

- [ ] Bump version and add tag
