### PR TITLE
Refactor/table row and table cell

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.45",
+  "version": "3.4.46",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amino-ui/core",
-  "version": "3.4.44",
+  "version": "3.4.45",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:amino-ui/core.git",
   "author": "Joshua Beitler <joshbeitler@gmail.com>",

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -49,7 +49,8 @@ export const Collapse = ({
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver(entries => {
-      setContentHeight(entries[0]?.contentRect.height);
+      // borderBoxSize will get the full box size including padding and border
+      setContentHeight(entries[0]?.borderBoxSize[0]?.blockSize);
     });
 
     if (contentWrapperRef.current) {

--- a/src/components/table/TableRow.tsx
+++ b/src/components/table/TableRow.tsx
@@ -4,7 +4,7 @@ import { theme } from 'src/styles/constants/theme';
 import styled from 'styled-components';
 
 const StyledTableRow = styled.tr`
-  :not(.no-hover):hover {
+  &.with-hover:hover {
     background-color: ${theme.gray50};
   }
   th {
@@ -24,7 +24,7 @@ export type TableRowProps = {
   active?: boolean;
   children: ReactNode;
   className?: string;
-  noHover?: boolean;
+  withHover?: boolean;
   onClick?: MouseEventHandler<HTMLTableRowElement>;
 };
 
@@ -32,7 +32,7 @@ export function TableRow({
   active,
   children,
   className,
-  noHover,
+  withHover,
   onClick,
 }: TableRowProps) {
   return (
@@ -40,7 +40,7 @@ export function TableRow({
       className={[
         className || '',
         active ? 'active' : '',
-        noHover ? 'no-hover' : '',
+        withHover ? 'with-hover' : '',
       ].join(' ')}
       onClick={onClick}
     >

--- a/src/components/table/TableRowCollapse.tsx
+++ b/src/components/table/TableRowCollapse.tsx
@@ -29,6 +29,12 @@ const StyledTableRow = styled(TableRow)<StyleProps>`
     `}
 `;
 
+const StyledCollapse = styled(Collapse)`
+  > div {
+    padding-bottom: ${theme.space16};
+  }
+`;
+
 const CollapsibleCell = styled(TableCell)<{ collapsed: boolean }>`
   border-bottom: ${p => (!p.collapsed ? 'inherit' : 0)};
   && {
@@ -54,6 +60,7 @@ export type TableRowCollapseProps = {
   children?: ReactNode;
   onToggleCollapse: MouseEventHandler<HTMLTableRowElement>;
   /**
+   * @param collapsed
    * @default false
    */
   collapsed?: boolean;
@@ -72,7 +79,7 @@ export const TableRowCollapse = ({
     <>
       <StyledTableRow
         collapsible={collapsible}
-        noHover={!collapsible}
+        withHover={collapsible}
         collapsed={collapsed}
         onClick={e => collapsible && onToggleCollapse(e)}
         className={className}
@@ -88,9 +95,9 @@ export const TableRowCollapse = ({
         </TableCell>
       </StyledTableRow>
       {collapsible && (
-        <TableRow noHover>
+        <TableRow>
           <CollapsibleCell colSpan={100} collapsed={collapsed}>
-            <Collapse collapsed={collapsed}>{children}</Collapse>
+            <StyledCollapse collapsed={collapsed}>{children}</StyledCollapse>
           </CollapsibleCell>
         </TableRow>
       )}


### PR DESCRIPTION
## Jira issue

<!-- [Jira issue description](url) -->
<!-- Example:
[3106 - Loup Charmant - Need dashboard switched from Hello](https://myzonos.atlassian.net/browse/DM-550)
-->
- New design in Figma has a space between each collapsible TableRow after it expanded.
- Collapse component is not getting the height that has padding

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR 
- adds space to each collapsible table row
- make no hover on `TableRow` by default, only have hover on table row if it's collapsible
- make `Collapse` to get the full height of the item with padding

## Todo

- [x] Bump version and add tag
